### PR TITLE
fix: eslint rules, import order/grouping, test dir

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,9 +20,22 @@ module.exports = [
   {
     files: ["**/*.mts", "**/*.ts"],
     rules: {
+      "import/first": "error",
       "import/newline-after-import": "error",
       "import/no-cycle": "error",
       "import/no-relative-parent-imports": "error",
+      "import/no-self-import": "error",
+      "import/order": [
+        "error",
+        {
+          groups: [["builtin", "external", "internal"], ["sibling", "parent"], ["index"]],
+          "newlines-between": "always",
+          alphabetize: {
+            order: "asc",
+            caseInsensitive: true,
+          },
+        },
+      ],
       "@nx/enforce-module-boundaries": [
         "error",
         {

--- a/package.json
+++ b/package.json
@@ -16,11 +16,12 @@
   "devDependencies": {
     "@eslint/eslintrc": "^2.1.1",
     "@faker-js/faker": "^8.1.0",
+    "@microsoft/tsdoc-config": "^0.16.2",
     "@nx/eslint-plugin": "16.9.1",
     "@nx/js": "16.9.1",
     "@nx/vite": "16.9.1",
     "@nx/workspace": "16.9.1",
-    "@types/node": "^20.6.3",
+    "@types/node": "^20.7.1",
     "@typescript-eslint/eslint-plugin": "^6.7.0",
     "@typescript-eslint/parser": "^6.7.0",
     "@vitest/coverage-v8": "^0.34.0",

--- a/packages/ffx-api/src/lib/api.mts
+++ b/packages/ffx-api/src/lib/api.mts
@@ -2,9 +2,12 @@
  * Do something cool.
  *
  * @example
+ *
+ * ```ts
  * import { api } from "@oberan/ffx-api";
  *
  * api();
+ * ```
  *
  * @since 0.1.0
  */

--- a/packages/ffx-api/test/api.spec.mts
+++ b/packages/ffx-api/test/api.spec.mts
@@ -1,4 +1,4 @@
-import { api } from "./api.mjs";
+import { api } from "../src/lib/api.mjs";
 
 describe("api", () => {
   it("should work", () => {

--- a/packages/ffx-api/tsconfig.lib.json
+++ b/packages/ffx-api/tsconfig.lib.json
@@ -7,5 +7,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*.mts"],
-  "exclude": ["src/**/*.spec.mts"]
+  "exclude": ["test/**/*.spec.mts"]
 }

--- a/packages/ffx-api/tsconfig.spec.json
+++ b/packages/ffx-api/tsconfig.spec.json
@@ -4,5 +4,5 @@
     "outDir": "../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },
-  "include": ["vite.config.ts", "src/**/*.spec.mts", "src/**/*.d.mts"]
+  "include": ["vite.config.ts", "test/**/*.spec.mts", "src/**/*.d.mts"]
 }

--- a/packages/ffx-api/tsdoc.json
+++ b/packages/ffx-api/tsdoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["../../tsdoc.base.json"]
+}

--- a/packages/ffx-api/vite.config.ts
+++ b/packages/ffx-api/vite.config.ts
@@ -1,6 +1,6 @@
 /// <reference types="vitest" />
-import { defineConfig } from "vite";
 import { nxViteTsPaths } from "@nx/vite/plugins/nx-tsconfig-paths.plugin";
+import { defineConfig } from "vite";
 
 export default defineConfig({
   cacheDir: "../../node_modules/.vite/ffx-api",
@@ -21,6 +21,6 @@ export default defineConfig({
     },
     environment: "node",
     globals: true,
-    include: ["src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}"],
+    include: ["test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}"],
   },
 });

--- a/packages/ffx-guards/project.json
+++ b/packages/ffx-guards/project.json
@@ -21,7 +21,9 @@
       "executor": "@nx/vite:test",
       "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "passWithNoTests": true,
+        "coverage": true,
+        "passWithNoTests": false,
+        "reporters": ["default"],
         "reportsDirectory": "../../coverage/packages/ffx-guards"
       }
     }

--- a/packages/ffx-guards/src/lib/guards.mts
+++ b/packages/ffx-guards/src/lib/guards.mts
@@ -16,9 +16,7 @@ type Falsy = null | undefined | false | "" | 0;
  * Helper function to determine if a value is `null`.
  * Useful in if/else statements or ternaries.
  *
- * @param {*} x - Any object/value
- *
- * @example Simple usage
+ * @example
  *
  * ```ts
  * if (isNull(x)) {
@@ -36,9 +34,7 @@ export const isNull = (x: unknown): x is null => x === null;
  * Helper function to determine if a value is `undefined`.
  * Useful in if/else statements or ternaries.
  *
- * @param {*} x - Any object/value
- *
- * @example Simple usage
+ * @example
  *
  * ```ts
  * if (isUndefined(x)) {
@@ -56,9 +52,7 @@ export const isUndefined = (x: unknown): x is undefined => x === undefined;
  * Helper function to determine if a value is `null`, `undefined` or an empty string.
  * Useful in if/else statements or ternaries.
  *
- * @param {*} x - Any object/value
- *
- * @example Simple usage
+ * @example
  *
  * ```ts
  * if (isNil(x)) {
@@ -77,9 +71,7 @@ export const isNil = (x: unknown): x is Nil =>
  * Helper function to determine if a value is NOT `null` or `undefined`.
  * Useful in if/else statements or ternaries.
  *
- * @param {*} x - Any object/value
- *
- * @example Simple usage
+ * @example
  *
  * ```ts
  * if (isNotNil(x)) {
@@ -97,9 +89,7 @@ export const isNotNil = <T,>(x: T | Nil): x is T => !isNil(x);
  * Helper function to determine if a value is falsy.
  * Useful in if/else statements or ternaries.
  *
- * @param {*} x - Any object/value
- *
- * @example Simple usage
+ * @example
  *
  * ```ts
  * if (isFalsy(x)) {
@@ -118,9 +108,7 @@ export const isFalsy = (x: unknown): x is Falsy =>
  * Helper function to determine if a value is truthy.
  * Useful in if/else statements or ternaries.
  *
- * @param {*} x - Any object/value
- *
- * @example Simple usage
+ * @example
  *
  * ```ts
  * if (isTruthy(x)) {
@@ -138,9 +126,7 @@ export const isTruthy = (x: unknown): x is true => !isFalsy(x);
  * Helper function to determine if a value is a string.
  * Useful in if/else statements or ternaries.
  *
- * @param {*} x - Any object/value
- *
- * @example Simple usage
+ * @example
  *
  * ```ts
  * if (isString(x)) {
@@ -158,9 +144,7 @@ export const isString = (x: unknown): x is string => typeof x === "string";
  * Helper function to determine if a value is a number.
  * Useful in if/else statements or ternaries.
  *
- * @param {*} x - Any object/value
- *
- * @example Simple usage
+ * @example
  *
  * ```ts
  * if (isNumber(x)) {
@@ -178,9 +162,7 @@ export const isNumber = (x: unknown): x is number => typeof x === "number";
  * Helper function to determine if a value is a date.
  * Useful in if/else statements or ternaries.
  *
- * @param {*} x - Any object/value
- *
- * @example Simple usage
+ * @example
  *
  * ```ts
  * if (isDate(x)) {
@@ -201,9 +183,7 @@ export const isDate = (x: unknown): x is Date => x instanceof Date;
  * Note: Does not verify that each value in the array is of type T
  * since the type system does not exist at _runtime_.
  *
- * @param {*} x - Any object/value
- *
- * @example Simple usage
+ * @example
  *
  * ```ts
  * if (isArray<string>(x)) {

--- a/packages/ffx-guards/test/guards.spec.mts
+++ b/packages/ffx-guards/test/guards.spec.mts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 
-import * as G from "./guards.mjs";
+import * as G from "../src/lib/guards.mjs";
 
 describe("ffx-guards", () => {
   it("isNull()", () => {

--- a/packages/ffx-guards/tsconfig.lib.json
+++ b/packages/ffx-guards/tsconfig.lib.json
@@ -7,5 +7,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*.mts"],
-  "exclude": ["src/**/*.spec.mts"]
+  "exclude": ["test/**/*.spec.mts"]
 }

--- a/packages/ffx-guards/tsconfig.spec.json
+++ b/packages/ffx-guards/tsconfig.spec.json
@@ -4,5 +4,5 @@
     "outDir": "../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },
-  "include": ["vite.config.ts", "src/**/*.spec.mts", "src/**/*.d.mts"]
+  "include": ["vite.config.ts", "test/**/*.spec.mts", "src/**/*.d.mts"]
 }

--- a/packages/ffx-guards/tsdoc.json
+++ b/packages/ffx-guards/tsdoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["../../tsdoc.base.json"]
+}

--- a/packages/ffx-guards/vite.config.ts
+++ b/packages/ffx-guards/vite.config.ts
@@ -1,6 +1,6 @@
 /// <reference types='vitest' />
-import { defineConfig } from "vite";
 import { nxViteTsPaths } from "@nx/vite/plugins/nx-tsconfig-paths.plugin";
+import { defineConfig } from "vite";
 
 export default defineConfig({
   cacheDir: "../../node_modules/.vite/ffx-guards",
@@ -21,6 +21,6 @@ export default defineConfig({
     },
     environment: "node",
     globals: true,
-    include: ["src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}"],
+    include: ["test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}"],
   },
 });

--- a/packages/ffx-logger/src/lib/logger.mts
+++ b/packages/ffx-logger/src/lib/logger.mts
@@ -11,6 +11,8 @@ interface Logger {
  * Custom logger for plugins useful for debugging.
  *
  * @example
+ *
+ * ```ts
  * import mklogger from "@obearn/ffx-logger";
  *
  * import pkgJson from "./package.json";
@@ -19,6 +21,7 @@ interface Logger {
  * const logger = mkLogger(pkgJson.name);
  *
  * logger.info("Hello World!");
+ * ```
  *
  * @since 0.1.0
  */

--- a/packages/ffx-logger/test/logger.spec.mts
+++ b/packages/ffx-logger/test/logger.spec.mts
@@ -1,7 +1,5 @@
-import mkLogger from "./logger.mjs";
-
-// eslint-disable-next-line import/no-relative-parent-imports
-import pkgJson from "../../package.json";
+import pkgJson from "../package.json"; // eslint-disable-line import/no-relative-parent-imports
+import mkLogger from "../src/lib/logger.mjs";
 
 describe("logger", () => {
   const logger = mkLogger(pkgJson.name);

--- a/packages/ffx-logger/tsconfig.lib.json
+++ b/packages/ffx-logger/tsconfig.lib.json
@@ -7,5 +7,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*.mts"],
-  "exclude": ["src/**/*.spec.mts"]
+  "exclude": ["test/**/*.spec.mts"]
 }

--- a/packages/ffx-logger/tsconfig.spec.json
+++ b/packages/ffx-logger/tsconfig.spec.json
@@ -5,5 +5,5 @@
     "resolveJsonModule": true,
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },
-  "include": ["vite.config.ts", "src/**/*.spec.mts", "src/**/*.d.mts"]
+  "include": ["vite.config.ts", "test/**/*.spec.mts", "src/**/*.d.mts"]
 }

--- a/packages/ffx-logger/tsdoc.json
+++ b/packages/ffx-logger/tsdoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["../../tsdoc.base.json"]
+}

--- a/packages/ffx-logger/vite.config.ts
+++ b/packages/ffx-logger/vite.config.ts
@@ -1,6 +1,6 @@
 /// <reference types='vitest' />
-import { defineConfig } from "vite";
 import { nxViteTsPaths } from "@nx/vite/plugins/nx-tsconfig-paths.plugin";
+import { defineConfig } from "vite";
 
 export default defineConfig({
   cacheDir: "../../node_modules/.vite/ffx-logger",
@@ -21,6 +21,6 @@ export default defineConfig({
     },
     environment: "node",
     globals: true,
-    include: ["src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}"],
+    include: ["test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}"],
   },
 });

--- a/packages/ffx-orm/project.json
+++ b/packages/ffx-orm/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@obera/ffx-orm",
+  "name": "ffx-orm",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/ffx-orm/src",
   "projectType": "library",

--- a/packages/ffx-orm/vite.config.ts
+++ b/packages/ffx-orm/vite.config.ts
@@ -1,6 +1,6 @@
 /// <reference types='vitest' />
-import { defineConfig } from "vite";
 import { nxViteTsPaths } from "@nx/vite/plugins/nx-tsconfig-paths.plugin";
+import { defineConfig } from "vite";
 
 export default defineConfig({
   cacheDir: "../../node_modules/.vite/ffx-orm",

--- a/packages/ffx-parser-address-geocodio/src/lib/geocodio.mts
+++ b/packages/ffx-parser-address-geocodio/src/lib/geocodio.mts
@@ -119,10 +119,6 @@ type CountryCode = "CA" | "US";
 //       Main
 // ===================
 
-/**
- * @constructor
- * @param apiKey
- */
 export default class Geocodio {
   #apiKey: string;
 
@@ -133,11 +129,9 @@ export default class Geocodio {
   /**
    * Parse a single address.
    *
-   * @param address - Address to parse.
-   * @param countryCode - Country for the API to use when attempting to parse the address.
    * @see {@link https://www.geocod.io/docs/?shell#single-address} for reference.
    *
-   * @example Simple usage
+   * @example
    *
    * ```ts
    * import Geocodio from "@oberan/ffx-address-geocodio";
@@ -179,11 +173,9 @@ export default class Geocodio {
   /**
    * Parse multiple addresses (up to 10K) at one time.
    *
-   * @param addresses - List of addresses to parse.
-   * @param limit - If set to 0, no limit will be applied.
    * @see {@link https://www.geocod.io/docs/?shell#batch-geocoding} for reference.
    *
-   * @example Simple usage
+   * @example
    *
    * ```ts
    * import Geocodio from "@oberan/ffx-address-geocodio";

--- a/packages/ffx-parser-address-geocodio/test/geocodio.spec.mts
+++ b/packages/ffx-parser-address-geocodio/test/geocodio.spec.mts
@@ -1,8 +1,8 @@
 import { faker, fakerEN_US } from "@faker-js/faker";
-import { pipe } from "fp-ts/function";
 import * as E from "fp-ts/Either";
-import { setupServer } from "msw/node";
+import { pipe } from "fp-ts/function";
 import { rest } from "msw";
+import { setupServer } from "msw/node";
 
 import Geocodio, {
   AccuracyType,
@@ -18,7 +18,7 @@ import Geocodio, {
   HttpMethodCodec,
   SingleAddressResponse,
   SingleAddressResponseCodec,
-} from "./geocodio.mjs";
+} from "../src/lib/geocodio.mjs";
 
 const _mkAccuracyType = (): AccuracyType => {
   return faker.helpers.arrayElement([

--- a/packages/ffx-parser-address-geocodio/tsconfig.lib.json
+++ b/packages/ffx-parser-address-geocodio/tsconfig.lib.json
@@ -7,5 +7,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*.mts"],
-  "exclude": ["src/**/*.spec.mts"]
+  "exclude": ["test/**/*.spec.mts"]
 }

--- a/packages/ffx-parser-address-geocodio/tsconfig.spec.json
+++ b/packages/ffx-parser-address-geocodio/tsconfig.spec.json
@@ -4,5 +4,5 @@
     "outDir": "../../dist/out-tsc",
     "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
   },
-  "include": ["vite.config.ts", "src/**/*.spec.mts", "src/**/*.d.mts"]
+  "include": ["vite.config.ts", "test/**/*.spec.mts", "src/**/*.d.mts"]
 }

--- a/packages/ffx-parser-address-geocodio/tsdoc.json
+++ b/packages/ffx-parser-address-geocodio/tsdoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["../../tsdoc.base.json"]
+}

--- a/packages/ffx-parser-address-geocodio/vite.config.ts
+++ b/packages/ffx-parser-address-geocodio/vite.config.ts
@@ -1,6 +1,6 @@
 /// <reference types='vitest' />
-import { defineConfig } from "vite";
 import { nxViteTsPaths } from "@nx/vite/plugins/nx-tsconfig-paths.plugin";
+import { defineConfig } from "vite";
 
 export default defineConfig({
   cacheDir: "../../node_modules/.vite/ffx-parser-address-geocodio",
@@ -21,6 +21,6 @@ export default defineConfig({
     },
     environment: "node",
     globals: true,
-    include: ["src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}"],
+    include: ["test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}"],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,21 +30,24 @@ importers:
       '@faker-js/faker':
         specifier: ^8.1.0
         version: 8.1.0
+      '@microsoft/tsdoc-config':
+        specifier: ^0.16.2
+        version: 0.16.2
       '@nx/eslint-plugin':
         specifier: 16.9.1
-        version: 16.9.1(@types/node@20.7.0)(@typescript-eslint/parser@6.7.3)(eslint-config-prettier@9.0.0)(eslint@8.50.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)
+        version: 16.9.1(@types/node@20.7.1)(@typescript-eslint/parser@6.7.3)(eslint-config-prettier@9.0.0)(eslint@8.50.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)
       '@nx/js':
         specifier: 16.9.1
-        version: 16.9.1(@types/node@20.7.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)
+        version: 16.9.1(@types/node@20.7.1)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)
       '@nx/vite':
         specifier: 16.9.1
-        version: 16.9.1(@types/node@20.7.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)(vite@4.4.9)(vitest@0.34.5)
+        version: 16.9.1(@types/node@20.7.1)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)(vite@4.4.9)(vitest@0.34.5)
       '@nx/workspace':
         specifier: 16.9.1
         version: 16.9.1
       '@types/node':
-        specifier: ^20.6.3
-        version: 20.7.0
+        specifier: ^20.7.1
+        version: 20.7.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.7.0
         version: 6.7.3(@typescript-eslint/parser@6.7.3)(eslint@8.50.0)(typescript@5.2.2)
@@ -95,7 +98,7 @@ importers:
         version: 5.26.3(typanion@3.14.0)
       vite:
         specifier: ^4.4.0
-        version: 4.4.9(@types/node@20.7.0)
+        version: 4.4.9(@types/node@20.7.1)
       vitest:
         specifier: ^0.34.0
         version: 0.34.5(@vitest/ui@0.34.5)
@@ -1765,10 +1768,10 @@ packages:
       - nx
     dev: true
 
-  /@nrwl/eslint-plugin-nx@16.9.1(@types/node@20.7.0)(@typescript-eslint/parser@6.7.3)(eslint-config-prettier@9.0.0)(eslint@8.50.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3):
+  /@nrwl/eslint-plugin-nx@16.9.1(@types/node@20.7.1)(@typescript-eslint/parser@6.7.3)(eslint-config-prettier@9.0.0)(eslint@8.50.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3):
     resolution: {integrity: sha512-G1bHWYgZuuXz51leJgleFltiyVzXpE5jKcApnSMnzbnP0HzeJO9QHruCX+t7bST3SXDV1uVXgovLyqfffCkNNA==}
     dependencies:
-      '@nx/eslint-plugin': 16.9.1(@types/node@20.7.0)(@typescript-eslint/parser@6.7.3)(eslint-config-prettier@9.0.0)(eslint@8.50.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)
+      '@nx/eslint-plugin': 16.9.1(@types/node@20.7.1)(@typescript-eslint/parser@6.7.3)(eslint-config-prettier@9.0.0)(eslint@8.50.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -1785,10 +1788,10 @@ packages:
       - verdaccio
     dev: true
 
-  /@nrwl/js@16.9.1(@types/node@20.7.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3):
+  /@nrwl/js@16.9.1(@types/node@20.7.1)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3):
     resolution: {integrity: sha512-v4EZ5nCmqsSHm5iKDwK2fv8Yg+i2UwGlt3wcbULmuFTAD/F1/VM68yWK2hBQSPCENhua1BAQ2T+VXBtGmZShaQ==}
     dependencies:
-      '@nx/js': 16.9.1(@types/node@20.7.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)
+      '@nx/js': 16.9.1(@types/node@20.7.1)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -1814,10 +1817,10 @@ packages:
       - debug
     dev: true
 
-  /@nrwl/vite@16.9.1(@types/node@20.7.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)(vite@4.4.9)(vitest@0.34.5):
+  /@nrwl/vite@16.9.1(@types/node@20.7.1)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)(vite@4.4.9)(vitest@0.34.5):
     resolution: {integrity: sha512-v7ttx8xIdlfsq4zW0JiyX3hi8btp8B4DlqlXQCTR9RWjEKnLEvRpv28vA50BIAVFk9JDjJhuBdelTKlETZzTew==}
     dependencies:
-      '@nx/vite': 16.9.1(@types/node@20.7.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)(vite@4.4.9)(vitest@0.34.5)
+      '@nx/vite': 16.9.1(@types/node@20.7.1)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)(vite@4.4.9)(vitest@0.34.5)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -1858,7 +1861,7 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /@nx/eslint-plugin@16.9.1(@types/node@20.7.0)(@typescript-eslint/parser@6.7.3)(eslint-config-prettier@9.0.0)(eslint@8.50.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3):
+  /@nx/eslint-plugin@16.9.1(@types/node@20.7.1)(@typescript-eslint/parser@6.7.3)(eslint-config-prettier@9.0.0)(eslint@8.50.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3):
     resolution: {integrity: sha512-pBZYZRyeM+rxDW3mBXFz4fjXEb43sVLWHcjgMOlSkYQz79NY0YK0sntBxBCVIUNQF/rES8ZEzhfr3a+3fWgptA==}
     peerDependencies:
       '@typescript-eslint/parser': ^5.60.1
@@ -1867,9 +1870,9 @@ packages:
       eslint-config-prettier:
         optional: true
     dependencies:
-      '@nrwl/eslint-plugin-nx': 16.9.1(@types/node@20.7.0)(@typescript-eslint/parser@6.7.3)(eslint-config-prettier@9.0.0)(eslint@8.50.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)
+      '@nrwl/eslint-plugin-nx': 16.9.1(@types/node@20.7.1)(@typescript-eslint/parser@6.7.3)(eslint-config-prettier@9.0.0)(eslint@8.50.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)
       '@nx/devkit': 16.9.1(nx@16.9.1)
-      '@nx/js': 16.9.1(@types/node@20.7.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)
+      '@nx/js': 16.9.1(@types/node@20.7.1)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)
       '@typescript-eslint/parser': 6.7.3(eslint@8.50.0)(typescript@5.2.2)
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.50.0)(typescript@5.2.2)
       '@typescript-eslint/utils': 5.62.0(eslint@8.50.0)(typescript@5.2.2)
@@ -1893,7 +1896,7 @@ packages:
       - verdaccio
     dev: true
 
-  /@nx/js@16.9.1(@types/node@20.7.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3):
+  /@nx/js@16.9.1(@types/node@20.7.1)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3):
     resolution: {integrity: sha512-gUs1GoFtQ4OkJhgQmOkgY9bEZd3aWZwi1OsZHiDxQ7NQzNzP438ZibiZua/YCrzd0lmdwU9YPHfG9tXyoAZKuA==}
     peerDependencies:
       verdaccio: ^5.0.4
@@ -1908,7 +1911,7 @@ packages:
       '@babel/preset-env': 7.22.20(@babel/core@7.23.0)
       '@babel/preset-typescript': 7.23.0(@babel/core@7.23.0)
       '@babel/runtime': 7.23.1
-      '@nrwl/js': 16.9.1(@types/node@20.7.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)
+      '@nrwl/js': 16.9.1(@types/node@20.7.1)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)
       '@nx/devkit': 16.9.1(nx@16.9.1)
       '@nx/workspace': 16.9.1
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.2.2)
@@ -1928,7 +1931,7 @@ packages:
       ora: 5.3.0
       semver: 7.5.3
       source-map-support: 0.5.19
-      ts-node: 10.9.1(@types/node@20.7.0)(typescript@5.2.2)
+      ts-node: 10.9.1(@types/node@20.7.1)(typescript@5.2.2)
       tsconfig-paths: 4.2.0
       tslib: 2.6.2
       verdaccio: 5.26.3(typanion@3.14.0)
@@ -2034,20 +2037,20 @@ packages:
     dev: true
     optional: true
 
-  /@nx/vite@16.9.1(@types/node@20.7.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)(vite@4.4.9)(vitest@0.34.5):
+  /@nx/vite@16.9.1(@types/node@20.7.1)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)(vite@4.4.9)(vitest@0.34.5):
     resolution: {integrity: sha512-+AlUq3XIefGE49KFAcXDO9P0rWGCouQrmTyZCD3O7q4Ym8CHpKc1cIRhrkRLV341Z7cLv0JXGIl7Bv5vLnnkEQ==}
     peerDependencies:
       vite: ^4.3.4
       vitest: '>=0.31.0 <1.0.0'
     dependencies:
-      '@nrwl/vite': 16.9.1(@types/node@20.7.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)(vite@4.4.9)(vitest@0.34.5)
+      '@nrwl/vite': 16.9.1(@types/node@20.7.1)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)(vite@4.4.9)(vitest@0.34.5)
       '@nx/devkit': 16.9.1(nx@16.9.1)
-      '@nx/js': 16.9.1(@types/node@20.7.0)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)
+      '@nx/js': 16.9.1(@types/node@20.7.1)(nx@16.9.1)(typescript@5.2.2)(verdaccio@5.26.3)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.2.2)
       '@swc/helpers': 0.5.2
       enquirer: 2.3.6
       tsconfig-paths: 4.2.0
-      vite: 4.4.9(@types/node@20.7.0)
+      vite: 4.4.9(@types/node@20.7.1)
       vitest: 0.34.5(@vitest/ui@0.34.5)
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -2176,8 +2179,8 @@ packages:
     resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
     dev: true
 
-  /@types/node@20.7.0:
-    resolution: {integrity: sha512-zI22/pJW2wUZOVyguFaUL1HABdmSVxpXrzIqkjsHmyUjNhPoWM1CKfvVuXfetHhIok4RY573cqS0mZ1SJEnoTg==}
+  /@types/node@20.7.1:
+    resolution: {integrity: sha512-LT+OIXpp2kj4E2S/p91BMe+VgGX2+lfO+XTpfXhh+bCk2LkQtHZSub8ewFBMGP5ClysPjTDFa4sMI8Q3n4T0wg==}
     dev: true
 
   /@types/parse-json@4.0.0:
@@ -2191,7 +2194,7 @@ packages:
   /@types/set-cookie-parser@2.4.4:
     resolution: {integrity: sha512-xCfTC/eL/GmvMC24b42qJpYSTdCIBwWcfskDF80ztXtnU6pKXyvuZP2EConb2K9ps0s7gMhCa0P1foy7wiItMA==}
     dependencies:
-      '@types/node': 20.7.0
+      '@types/node': 20.7.1
     dev: true
 
   /@typescript-eslint/eslint-plugin@6.7.3(@typescript-eslint/parser@6.7.3)(eslint@8.50.0)(typescript@5.2.2):
@@ -6748,7 +6751,7 @@ packages:
       typescript: 5.2.2
     dev: true
 
-  /ts-node@10.9.1(@types/node@20.7.0)(typescript@5.2.2):
+  /ts-node@10.9.1(@types/node@20.7.1)(typescript@5.2.2):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -6767,7 +6770,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.7.0
+      '@types/node': 20.7.1
       acorn: 8.10.0
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -7149,7 +7152,7 @@ packages:
       extsprintf: 1.3.0
     dev: true
 
-  /vite-node@0.34.5(@types/node@20.7.0):
+  /vite-node@0.34.5(@types/node@20.7.1):
     resolution: {integrity: sha512-RNZ+DwbCvDoI5CbCSQSyRyzDTfFvFauvMs6Yq4ObJROKlIKuat1KgSX/Ako5rlDMfVCyMcpMRMTkJBxd6z8YRA==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -7159,7 +7162,7 @@ packages:
       mlly: 1.4.2
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.4.9(@types/node@20.7.0)
+      vite: 4.4.9(@types/node@20.7.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -7171,7 +7174,7 @@ packages:
       - terser
     dev: true
 
-  /vite@4.4.9(@types/node@20.7.0):
+  /vite@4.4.9(@types/node@20.7.1):
     resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -7199,7 +7202,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.7.0
+      '@types/node': 20.7.1
       esbuild: 0.18.20
       postcss: 8.4.30
       rollup: 3.29.3
@@ -7240,7 +7243,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.6
       '@types/chai-subset': 1.3.3
-      '@types/node': 20.7.0
+      '@types/node': 20.7.1
       '@vitest/expect': 0.34.5
       '@vitest/runner': 0.34.5
       '@vitest/snapshot': 0.34.5
@@ -7260,8 +7263,8 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.5.1
       tinypool: 0.7.0
-      vite: 4.4.9(@types/node@20.7.0)
-      vite-node: 0.34.5(@types/node@20.7.0)
+      vite: 4.4.9(@types/node@20.7.1)
+      vite-node: 0.34.5(@types/node@20.7.1)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/tsdoc.base.json
+++ b/tsdoc.base.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "noStandardTags": false,
+  "tagDefinitions": [
+    {
+      "tagName": "@since",
+      "syntaxKind": "modifier"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

- Moved all tests to a `test` folder in each project (will fix `ffx-orm` in another PR)
- Added import ordering rule by grouping
- Added rule to sort imports alphabetically
- Added TSDoc linting support to all projects
- Added missing test coverage config options

## Type of change

Please delete options that are not relevant.

- [x] Chore (docs, deps, small refactorings, etc)

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests (when necessary).
- [x] I have documented the code with examples and TSDoc.
