### PR TITLE
feat(ffx-logger): add timestamp and make prettier

### DIFF
--- a/packages/ffx-cli/package.json
+++ b/packages/ffx-cli/package.json
@@ -29,9 +29,9 @@
     "@clack/prompts": "^0.7.0",
     "chalk": "^5.3.0",
     "commander": "^11.0.0",
-    "execa": "^8.0.1",
-    "fp-ts": "^2.16.1",
+    "execa": "^8.0.0",
+    "fp-ts": "^2.16.0",
     "io-ts": "^2.2.20",
-    "ts-pattern": "^5.0.5"
+    "ts-pattern": "^5.0.0"
   }
 }

--- a/packages/ffx-logger/package.json
+++ b/packages/ffx-logger/package.json
@@ -26,5 +26,9 @@
     "type": "git",
     "url": "https://github.com/oberandev/ffx.git",
     "directory": "packages/ffx-logger"
+  },
+  "dependencies": {
+    "chalk": "^5.3.0",
+    "fp-ts": "^2.16.0"
   }
 }

--- a/packages/ffx-logger/src/lib/logger.mts
+++ b/packages/ffx-logger/src/lib/logger.mts
@@ -1,10 +1,12 @@
 import chalk from "chalk";
-import * as IO from "fp-ts/IO";
+import * as IO from "fp-ts/lib/IO.js";
 
 interface Logger {
-  fatal: (msg: string) => IO.IO<void>;
-  info: (msg: string) => IO.IO<void>;
-  warn: (msg: string) => IO.IO<void>;
+  readonly debug: (msg: string) => IO.IO<void>;
+  readonly fatal: (msg: string) => IO.IO<void>;
+  readonly info: (msg: string) => IO.IO<void>;
+  readonly trace: (msg: string) => IO.IO<void>;
+  readonly warn: (msg: string) => IO.IO<void>;
 }
 
 /**

--- a/packages/ffx-logger/src/lib/logger.mts
+++ b/packages/ffx-logger/src/lib/logger.mts
@@ -15,7 +15,7 @@ interface Logger {
  * @example
  *
  * ```ts
- * import mklogger from "@obearn/ffx-logger";
+ * import mkLogger from "@obearn/ffx-logger";
  *
  * import pkgJson from "./package.json";
  * // note: you'll need `"resolveJsonModule": true` in your `tsconfig.json`
@@ -29,14 +29,55 @@ interface Logger {
  */
 function mkLogger(pluginName: string): Logger {
   return {
+    debug: (msg: string) => {
+      return IO.of(
+        console.debug(
+          `${chalk.inverse(` ${pluginName} | ${new Date().toISOString()} `)} ${chalk.blue(
+            "[DEBUG]",
+          )}`,
+          msg,
+        ),
+      );
+    },
     fatal: (msg: string) => {
-      return IO.of(console.error(chalk.red(`[${pluginName}]:[FATAL]`, msg)));
+      return IO.of(
+        console.error(
+          `${chalk.inverse(` ${pluginName} | ${new Date().toISOString()} `)} ${chalk.red(
+            "[FATAL]",
+          )}`,
+          msg,
+        ),
+      );
     },
     info: (msg: string) => {
-      return IO.of(console.info(chalk.grey(`[${pluginName}]:[INFO]`, msg)));
+      return IO.of(
+        console.info(
+          `${chalk.inverse(` ${pluginName} | ${new Date().toISOString()} `)} ${chalk.green(
+            "[INFO]",
+          )}`,
+          msg,
+        ),
+      );
+    },
+    trace: (msg: string) => {
+      return IO.of(
+        console.info(
+          `${chalk.inverse(` ${pluginName} | ${new Date().toISOString()} `)} ${chalk.magenta(
+            "[TRACE]",
+          )}`,
+          msg,
+        ),
+      );
     },
     warn: (msg: string) => {
-      return IO.of(console.warn(chalk.yellow(`[${pluginName}]:[WARN]`, msg)));
+      return IO.of(
+        console.warn(
+          `${chalk.inverse(` ${pluginName} | ${new Date().toISOString()} `)} ${chalk.yellow(
+            "[WARN]",
+          )}`,
+          msg,
+        ),
+      );
     },
   };
 }

--- a/packages/ffx-logger/test/logger.spec.mts
+++ b/packages/ffx-logger/test/logger.spec.mts
@@ -4,7 +4,15 @@ import mkLogger from "../src/lib/logger.mjs";
 describe("logger", () => {
   const logger = mkLogger(pkgJson.name);
 
-  it("should handle fatal messages", () => {
+  it("should handle a debug message", () => {
+    const spy = vi.spyOn(logger, "debug");
+
+    logger.debug("foo");
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle a fatal message", () => {
     const spy = vi.spyOn(logger, "fatal");
 
     logger.fatal("foo");
@@ -12,7 +20,7 @@ describe("logger", () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
-  it("should handle info messages", () => {
+  it("should handle a info message", () => {
     const spy = vi.spyOn(logger, "info");
 
     logger.info("foo");
@@ -20,7 +28,15 @@ describe("logger", () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
-  it("should handle warn messages", () => {
+  it("should handle a trace message", () => {
+    const spy = vi.spyOn(logger, "trace");
+
+    logger.trace("foo");
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle a warn message", () => {
     const spy = vi.spyOn(logger, "warn");
 
     logger.warn("foo");

--- a/packages/ffx-parser-address-geocodio/src/lib/geocodio.mts
+++ b/packages/ffx-parser-address-geocodio/src/lib/geocodio.mts
@@ -1,8 +1,8 @@
 import axios, { AxiosError } from "axios";
-import { identity, pipe } from "fp-ts/function";
-import * as E from "fp-ts/Either";
-import * as TE from "fp-ts/TaskEither";
-import * as RA from "fp-ts/ReadonlyArray";
+import * as E from "fp-ts/lib/Either.js";
+import { identity, pipe } from "fp-ts/lib/function.js";
+import * as RA from "fp-ts/lib/ReadonlyArray.js";
+import * as TE from "fp-ts/lib/TaskEither.js";
 import * as t from "io-ts";
 import { failure } from "io-ts/PathReporter";
 

--- a/packages/ffx-parser-address-geocodio/src/lib/geocodio.mts
+++ b/packages/ffx-parser-address-geocodio/src/lib/geocodio.mts
@@ -120,7 +120,7 @@ type CountryCode = "CA" | "US";
 // ===================
 
 export default class Geocodio {
-  #apiKey: string;
+  readonly #apiKey: string;
 
   constructor(apiKey: string) {
     this.#apiKey = apiKey;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,21 +144,28 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0
       execa:
-        specifier: ^8.0.1
+        specifier: ^8.0.0
         version: 8.0.1
       fp-ts:
-        specifier: ^2.16.1
+        specifier: ^2.16.0
         version: 2.16.1
       io-ts:
         specifier: ^2.2.20
         version: 2.2.20(fp-ts@2.16.1)
       ts-pattern:
-        specifier: ^5.0.5
+        specifier: ^5.0.0
         version: 5.0.5
 
   packages/ffx-guards: {}
 
-  packages/ffx-logger: {}
+  packages/ffx-logger:
+    dependencies:
+      chalk:
+        specifier: ^5.3.0
+        version: 5.3.0
+      fp-ts:
+        specifier: ^2.16.0
+        version: 2.16.1
 
   packages/ffx-orm: {}
 


### PR DESCRIPTION
# Description

- Added timestamp to output as well as made it prettier with colors
- Added `trace` and `debug` functions
- Cleaned up all `fp-ts` imports to use esm

<img width="1148" alt="Screenshot 2023-10-01 at 12 38 51 PM" src="https://github.com/oberandev/ffx/assets/9221098/6d661e75-9e19-464f-a9cd-e319f6690213">

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests (when necessary).
- [x] I have documented the code with examples and TSDoc.
