### PR TITLE
chore: prefer es6 imports

### DIFF
--- a/packages/ffx-api/src/lib/agents.mts
+++ b/packages/ffx-api/src/lib/agents.mts
@@ -1,9 +1,9 @@
 import axios, { AxiosError } from "axios";
-import { identity, pipe } from "fp-ts/lib/function.js";
-import * as RT from "fp-ts/lib/ReaderTask.js";
-import * as RTE from "fp-ts/lib/ReaderTaskEither.js";
-import * as TE from "fp-ts/lib/TaskEither.js";
-import * as t from "io-ts/lib";
+import { identity, pipe } from "fp-ts/function";
+import * as RT from "fp-ts/ReaderTask";
+import * as RTE from "fp-ts/ReaderTaskEither";
+import * as TE from "fp-ts/TaskEither";
+import * as t from "io-ts";
 
 import {
   ApiReader,

--- a/packages/ffx-api/src/lib/documents.mts
+++ b/packages/ffx-api/src/lib/documents.mts
@@ -1,9 +1,9 @@
 import axios, { AxiosError } from "axios";
-import { identity, pipe } from "fp-ts/lib/function.js";
-import * as RT from "fp-ts/lib/ReaderTask.js";
-import * as RTE from "fp-ts/lib/ReaderTaskEither.js";
-import * as TE from "fp-ts/lib/TaskEither.js";
-import * as t from "io-ts/lib";
+import { identity, pipe } from "fp-ts/function";
+import * as RT from "fp-ts/ReaderTask";
+import * as RTE from "fp-ts/ReaderTaskEither";
+import * as TE from "fp-ts/TaskEither";
+import * as t from "io-ts";
 
 import {
   ApiReader,

--- a/packages/ffx-api/src/lib/types.mts
+++ b/packages/ffx-api/src/lib/types.mts
@@ -1,8 +1,8 @@
 import { AxiosError } from "axios";
-import * as E from "fp-ts/lib/Either.js";
-import { flow, pipe } from "fp-ts/lib/function.js";
-import * as RTE from "fp-ts/lib/ReaderTaskEither.js";
-import * as t from "io-ts/lib";
+import * as E from "fp-ts/Either";
+import { flow, pipe } from "fp-ts/function";
+import * as RTE from "fp-ts/ReaderTaskEither";
+import * as t from "io-ts";
 import { formatValidationErrors } from "io-ts-reporters";
 
 // ==================

--- a/packages/ffx-api/test/agents.spec.mts
+++ b/packages/ffx-api/test/agents.spec.mts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
-import * as E from "fp-ts/lib/Either.js";
-import { pipe } from "fp-ts/lib/function.js";
-import * as IO from "fp-ts/lib/IO.js";
+import * as E from "fp-ts/Either";
+import { pipe } from "fp-ts/function";
+import * as IO from "fp-ts/IO";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
 import { match } from "ts-pattern";

--- a/packages/ffx-api/test/documents.spec.mts
+++ b/packages/ffx-api/test/documents.spec.mts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
-import * as E from "fp-ts/lib/Either.js";
-import { pipe } from "fp-ts/lib/function.js";
-import * as IO from "fp-ts/lib/IO.js";
+import * as E from "fp-ts/Either";
+import { pipe } from "fp-ts/function";
+import * as IO from "fp-ts/IO";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
 import { match } from "ts-pattern";

--- a/packages/ffx-cli/src/index.mts
+++ b/packages/ffx-cli/src/index.mts
@@ -1,10 +1,10 @@
 import * as p from "@clack/prompts";
 import chalk from "chalk";
 import { Command } from "commander";
-import * as E from "fp-ts/lib/Either.js";
-import { pipe } from "fp-ts/lib/function.js";
-import * as RTE from "fp-ts/lib/ReaderTaskEither.js";
-import * as Str from "fp-ts/lib/string.js";
+import * as E from "fp-ts/Either";
+import { pipe } from "fp-ts/function";
+import * as RTE from "fp-ts/ReaderTaskEither";
+import * as Str from "fp-ts/string";
 
 import {
   ProjectCodec,

--- a/packages/ffx-cli/src/lib/helpers.mts
+++ b/packages/ffx-cli/src/lib/helpers.mts
@@ -1,9 +1,9 @@
 import { $ } from "execa";
-import * as E from "fp-ts/lib/Either.js";
-import { constVoid, pipe } from "fp-ts/lib/function.js";
-import * as J from "fp-ts/lib/Json.js";
-import * as RTE from "fp-ts/lib/ReaderTaskEither.js";
-import * as TE from "fp-ts/lib/TaskEither.js";
+import * as E from "fp-ts/Either";
+import { constVoid, pipe } from "fp-ts/function";
+import * as J from "fp-ts/Json";
+import * as RTE from "fp-ts/ReaderTaskEither";
+import * as TE from "fp-ts/TaskEither";
 import * as t from "io-ts";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";

--- a/packages/ffx-logger/src/lib/logger.mts
+++ b/packages/ffx-logger/src/lib/logger.mts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import * as IO from "fp-ts/lib/IO.js";
+import * as IO from "fp-ts/IO";
 
 interface Logger {
   readonly debug: (msg: string) => IO.IO<void>;

--- a/packages/ffx-orm/src/lib/blueprint.mts
+++ b/packages/ffx-orm/src/lib/blueprint.mts
@@ -1,5 +1,5 @@
-import { pipe } from "fp-ts/lib/function.js";
-import * as RA from "fp-ts/lib/ReadonlyArray.js";
+import { pipe } from "fp-ts/function";
+import * as RA from "fp-ts/ReadonlyArray";
 
 import { Sheet, eqSheet } from "./sheet.mjs";
 

--- a/packages/ffx-orm/src/lib/boolean_field.mts
+++ b/packages/ffx-orm/src/lib/boolean_field.mts
@@ -1,9 +1,9 @@
-import * as Eq from "fp-ts/lib/Eq.js";
-import { pipe } from "fp-ts/lib/function.js";
-import * as J from "fp-ts/lib/Json.js";
-import * as O from "fp-ts/lib/Option.js";
-import * as RA from "fp-ts/lib/ReadonlyArray.js";
-import * as Str from "fp-ts/lib/string.js";
+import * as Eq from "fp-ts/Eq";
+import { pipe } from "fp-ts/function";
+import * as J from "fp-ts/Json";
+import * as O from "fp-ts/Option";
+import * as RA from "fp-ts/ReadonlyArray";
+import * as Str from "fp-ts/string";
 
 type DbConstraint = RequiredConstraint;
 

--- a/packages/ffx-orm/src/lib/custom_action.mts
+++ b/packages/ffx-orm/src/lib/custom_action.mts
@@ -1,7 +1,7 @@
-import * as Eq from "fp-ts/lib/Eq.js";
-import { pipe } from "fp-ts/lib/function.js";
-import * as O from "fp-ts/lib/Option.js";
-import * as Str from "fp-ts/lib/string.js";
+import * as Eq from "fp-ts/Eq";
+import { pipe } from "fp-ts/function";
+import * as O from "fp-ts/Option";
+import * as Str from "fp-ts/string";
 
 type CusotmActionMode = "background" | "foreground";
 

--- a/packages/ffx-orm/src/lib/linked_field.mts
+++ b/packages/ffx-orm/src/lib/linked_field.mts
@@ -1,9 +1,9 @@
-import * as Eq from "fp-ts/lib/Eq.js";
-import { pipe } from "fp-ts/lib/function.js";
-import * as J from "fp-ts/lib/Json.js";
-import * as O from "fp-ts/lib/Option.js";
-import * as RA from "fp-ts/lib/ReadonlyArray.js";
-import * as Str from "fp-ts/lib/string.js";
+import * as Eq from "fp-ts/Eq";
+import { pipe } from "fp-ts/function";
+import * as J from "fp-ts/Json";
+import * as O from "fp-ts/Option";
+import * as RA from "fp-ts/ReadonlyArray";
+import * as Str from "fp-ts/string";
 
 type DbConstraint = RequiredConstraint | UniqueConstraint;
 

--- a/packages/ffx-orm/src/lib/number_field.mts
+++ b/packages/ffx-orm/src/lib/number_field.mts
@@ -1,9 +1,9 @@
-import * as Eq from "fp-ts/lib/Eq.js";
-import { pipe } from "fp-ts/lib/function.js";
-import * as J from "fp-ts/lib/Json.js";
-import * as O from "fp-ts/lib/Option.js";
-import * as RA from "fp-ts/lib/ReadonlyArray.js";
-import * as Str from "fp-ts/lib/string.js";
+import * as Eq from "fp-ts/Eq";
+import { pipe } from "fp-ts/function";
+import * as J from "fp-ts/Json";
+import * as O from "fp-ts/Option";
+import * as RA from "fp-ts/ReadonlyArray";
+import * as Str from "fp-ts/string";
 
 type DbConstraint = RequiredConstraint | UniqueConstraint;
 

--- a/packages/ffx-orm/src/lib/option_field.mts
+++ b/packages/ffx-orm/src/lib/option_field.mts
@@ -1,9 +1,9 @@
-import * as Eq from "fp-ts/lib/Eq.js";
-import { pipe } from "fp-ts/lib/function.js";
-import * as J from "fp-ts/lib/Json.js";
-import * as O from "fp-ts/lib/Option.js";
-import * as RA from "fp-ts/lib/ReadonlyArray.js";
-import * as Str from "fp-ts/lib/string.js";
+import * as Eq from "fp-ts/Eq";
+import { pipe } from "fp-ts/function";
+import * as J from "fp-ts/Json";
+import * as O from "fp-ts/Option";
+import * as RA from "fp-ts/ReadonlyArray";
+import * as Str from "fp-ts/string";
 
 type DbConstraint = RequiredConstraint | UniqueConstraint;
 

--- a/packages/ffx-orm/src/lib/sheet.mts
+++ b/packages/ffx-orm/src/lib/sheet.mts
@@ -1,10 +1,10 @@
-import * as Eq from "fp-ts/lib/Eq.js";
-import { pipe } from "fp-ts/lib/function.js";
-import * as J from "fp-ts/lib/Json.js";
-import * as O from "fp-ts/lib/Option.js";
-import * as RA from "fp-ts/lib/ReadonlyArray.js";
-import * as RNEA from "fp-ts/lib/ReadonlyNonEmptyArray.js";
-import * as Str from "fp-ts/lib/string.js";
+import * as Eq from "fp-ts/Eq";
+import { pipe } from "fp-ts/function";
+import * as J from "fp-ts/Json";
+import * as O from "fp-ts/Option";
+import * as RA from "fp-ts/ReadonlyArray";
+import * as RNEA from "fp-ts/ReadonlyNonEmptyArray";
+import * as Str from "fp-ts/string";
 
 import { BooleanField } from "./boolean_field.mjs";
 import { CustomAction, eqCustomAction } from "./custom_action.mjs";

--- a/packages/ffx-orm/src/lib/text_field.mts
+++ b/packages/ffx-orm/src/lib/text_field.mts
@@ -1,9 +1,9 @@
-import * as Eq from "fp-ts/lib/Eq.js";
-import { pipe } from "fp-ts/lib/function.js";
-import * as J from "fp-ts/lib/Json.js";
-import * as O from "fp-ts/lib/Option.js";
-import * as RA from "fp-ts/lib/ReadonlyArray.js";
-import * as Str from "fp-ts/lib/string.js";
+import * as Eq from "fp-ts/Eq";
+import { pipe } from "fp-ts/function";
+import * as J from "fp-ts/Json";
+import * as O from "fp-ts/Option";
+import * as RA from "fp-ts/ReadonlyArray";
+import * as Str from "fp-ts/string";
 
 type DbConstraint = RequiredConstraint | UniqueConstraint;
 

--- a/packages/ffx-orm/src/lib/workbook.mts
+++ b/packages/ffx-orm/src/lib/workbook.mts
@@ -1,8 +1,8 @@
-import { pipe } from "fp-ts/lib/function.js";
-import * as J from "fp-ts/lib/Json.js";
-import * as O from "fp-ts/lib/Option.js";
-import * as RA from "fp-ts/lib/ReadonlyArray.js";
-import * as Str from "fp-ts/lib/string.js";
+import { pipe } from "fp-ts/function";
+import * as J from "fp-ts/Json";
+import * as O from "fp-ts/Option";
+import * as RA from "fp-ts/ReadonlyArray";
+import * as Str from "fp-ts/string";
 
 import { CustomAction, eqCustomAction } from "./custom_action.mjs";
 import { Sheet, eqSheet } from "./sheet.mjs";

--- a/packages/ffx-orm/test/boolean_field.spec.mts
+++ b/packages/ffx-orm/test/boolean_field.spec.mts
@@ -1,4 +1,4 @@
-import * as J from "fp-ts/lib/Json.js";
+import * as J from "fp-ts/Json";
 
 import { BooleanFieldBuilder } from "../src/lib/boolean_field.mjs";
 

--- a/packages/ffx-orm/test/linked_field.spec.mts
+++ b/packages/ffx-orm/test/linked_field.spec.mts
@@ -1,4 +1,4 @@
-import * as J from "fp-ts/lib/Json.js";
+import * as J from "fp-ts/Json";
 
 import { LinkedFieldBuilder, SheetReferenceArgs } from "../src/lib/linked_field.mjs";
 

--- a/packages/ffx-orm/test/number_field.spec.mts
+++ b/packages/ffx-orm/test/number_field.spec.mts
@@ -1,4 +1,4 @@
-import * as J from "fp-ts/lib/Json.js";
+import * as J from "fp-ts/Json";
 
 import { NumberFieldBuilder } from "../src/lib/number_field.mjs";
 

--- a/packages/ffx-orm/test/option_field.spec.mts
+++ b/packages/ffx-orm/test/option_field.spec.mts
@@ -1,4 +1,4 @@
-import * as J from "fp-ts/lib/Json.js";
+import * as J from "fp-ts/Json";
 
 import { Choices, OptionFieldBuilder } from "../src/lib/option_field.mjs";
 

--- a/packages/ffx-orm/test/sheet.spec.mts
+++ b/packages/ffx-orm/test/sheet.spec.mts
@@ -1,7 +1,7 @@
-import { pipe } from "fp-ts/lib/function.js";
-import * as J from "fp-ts/lib/Json.js";
-import * as O from "fp-ts/lib/Option.js";
-import * as RA from "fp-ts/lib/ReadonlyArray.js";
+import { pipe } from "fp-ts/function";
+import * as J from "fp-ts/Json";
+import * as O from "fp-ts/Option";
+import * as RA from "fp-ts/ReadonlyArray";
 
 import { CustomActionBuilder, eqCustomAction } from "../src/lib/custom_action.mjs";
 import { eqField, Permission, SheetBuilder } from "../src/lib/sheet.mjs";

--- a/packages/ffx-orm/test/text_field.spec.mts
+++ b/packages/ffx-orm/test/text_field.spec.mts
@@ -1,4 +1,4 @@
-import * as J from "fp-ts/lib/Json.js";
+import * as J from "fp-ts/Json";
 
 import { TextFieldBuilder } from "../src/lib/text_field.mjs";
 

--- a/packages/ffx-orm/test/workbook.spec.mts
+++ b/packages/ffx-orm/test/workbook.spec.mts
@@ -1,7 +1,7 @@
-import { pipe } from "fp-ts/lib/function.js";
-import * as J from "fp-ts/lib/Json.js";
-import * as O from "fp-ts/lib/Option.js";
-import * as RA from "fp-ts/lib/ReadonlyArray.js";
+import { pipe } from "fp-ts/function";
+import * as J from "fp-ts/Json";
+import * as O from "fp-ts/Option";
+import * as RA from "fp-ts/ReadonlyArray";
 
 import { CustomActionBuilder, eqCustomAction } from "../src/lib/custom_action.mjs";
 import { SheetBuilder } from "../src/lib/sheet.mjs";

--- a/packages/ffx-parser-address-geocodio/src/lib/geocodio.mts
+++ b/packages/ffx-parser-address-geocodio/src/lib/geocodio.mts
@@ -1,9 +1,9 @@
 import axios, { AxiosError } from "axios";
-import * as E from "fp-ts/lib/Either.js";
-import { identity, pipe } from "fp-ts/lib/function.js";
-import * as RA from "fp-ts/lib/ReadonlyArray.js";
-import * as TE from "fp-ts/lib/TaskEither.js";
-import * as t from "io-ts/lib";
+import * as E from "fp-ts/Either";
+import { identity, pipe } from "fp-ts/function";
+import * as RA from "fp-ts/ReadonlyArray";
+import * as TE from "fp-ts/TaskEither";
+import * as t from "io-ts";
 import { formatValidationErrors } from "io-ts-reporters";
 
 // eslint-disable-next-line import/no-relative-parent-imports

--- a/packages/ffx-parser-address-geocodio/test/geocodio.spec.mts
+++ b/packages/ffx-parser-address-geocodio/test/geocodio.spec.mts
@@ -1,7 +1,7 @@
 import { faker, fakerEN_US } from "@faker-js/faker";
-import * as E from "fp-ts/lib/Either.js";
-import { pipe } from "fp-ts/lib/function.js";
-import * as IO from "fp-ts/lib/IO.js";
+import * as E from "fp-ts/Either";
+import { pipe } from "fp-ts/function";
+import * as IO from "fp-ts/IO";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
 import { match } from "ts-pattern";

--- a/packages/ffx-parser-boolean/src/lib/parser.mts
+++ b/packages/ffx-parser-boolean/src/lib/parser.mts
@@ -1,9 +1,9 @@
-import { Traversable } from "fp-ts/lib/Array.js";
-import * as E from "fp-ts/lib/Either.js";
-import { pipe } from "fp-ts/lib/function.js";
-import * as P from "parser-ts/lib/Parser.js";
-import { ParseResult } from "parser-ts/lib/ParseResult.js";
-import * as S from "parser-ts/lib/string.js";
+import { Traversable } from "fp-ts/Array";
+import * as E from "fp-ts/Either";
+import { pipe } from "fp-ts/function";
+import * as P from "parser-ts/Parser";
+import { ParseResult } from "parser-ts/ParseResult";
+import * as S from "parser-ts/string";
 
 // ==================
 //       Types

--- a/packages/ffx-parser-uuid/src/lib/parser.mts
+++ b/packages/ffx-parser-uuid/src/lib/parser.mts
@@ -1,13 +1,13 @@
-import * as E from "fp-ts/lib/Either.js";
-import * as Eq from "fp-ts/lib/Eq.js";
-import { pipe } from "fp-ts/lib/function.js";
-import * as Str from "fp-ts/lib/string.js";
-import { Iso } from "monocle-ts/lib";
-import * as N from "newtype-ts/lib";
-import * as C from "parser-ts/lib/char.js";
-import * as P from "parser-ts/lib/Parser.js";
-import { ParseResult } from "parser-ts/lib/ParseResult.js";
-import * as S from "parser-ts/lib/string.js";
+import * as E from "fp-ts/Either";
+import * as Eq from "fp-ts/Eq";
+import { pipe } from "fp-ts/function";
+import * as Str from "fp-ts/string";
+import { Iso } from "monocle-ts";
+import * as N from "newtype-ts";
+import * as C from "parser-ts/char";
+import * as P from "parser-ts/Parser";
+import { ParseResult } from "parser-ts/ParseResult";
+import * as S from "parser-ts/string";
 
 // ==================
 //       Types


### PR DESCRIPTION
# Description

Prefer es6 imports since these libraries `package.json` correctly specify `commonjs` or `es6` imports 😄 

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests (when necessary).
- [x] I have documented the code with examples and TSDoc.
