### PR TITLE
feat(ffx-parser-isbn): add initial parser

### DIFF
--- a/packages/ffx-parser-boolean/src/lib/parser.mts
+++ b/packages/ffx-parser-boolean/src/lib/parser.mts
@@ -11,25 +11,25 @@ import * as S from "parser-ts/string";
 
 const eof: P.Parser<string, void> = P.expected(P.eof(), "end of string");
 
-const pTrueShortform = pipe(
+const trueShortform = pipe(
   S.oneOf(Traversable)(["t", "y", "1"]),
   P.apFirst(eof),
   P.map(() => true),
 );
 
-const pFalseShortform = pipe(
+const falseShortform = pipe(
   S.oneOf(Traversable)(["f", "n", "0"]),
   P.apFirst(eof),
   P.map(() => false),
 );
 
-const pTrueLongform = pipe(
+const trueLongform = pipe(
   S.oneOf(Traversable)(["on", "yes", "true"]),
   P.apFirst(eof),
   P.map(() => true),
 );
 
-const pFalseLongform = pipe(
+const falseLongform = pipe(
   S.oneOf(Traversable)(["off", "no", "false"]),
   P.apFirst(eof),
   P.map(() => false),
@@ -37,8 +37,8 @@ const pFalseLongform = pipe(
 
 export function runParser(input: string): ParseResult<string, boolean> {
   const parser = pipe(
-    P.either(pTrueLongform, () => pFalseLongform),
-    P.alt(() => P.either(pTrueShortform, () => pFalseShortform)),
+    P.either(trueLongform, () => falseLongform),
+    P.alt(() => P.either(trueShortform, () => falseShortform)),
   );
 
   return S.run(input)(parser);

--- a/packages/ffx-parser-isbn/CHANGELOG.md
+++ b/packages/ffx-parser-isbn/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+All new changes are documented in `CHANGELOG.md` files in each package's directory.

--- a/packages/ffx-parser-isbn/README.md
+++ b/packages/ffx-parser-isbn/README.md
@@ -1,0 +1,11 @@
+# ffx-parser-isbn
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build ffx-parser-isbn` to build the library.
+
+## Running unit tests
+
+Run `nx test ffx-parser-isbn` to execute the unit tests via [Jest](https://jestjs.io).

--- a/packages/ffx-parser-isbn/build
+++ b/packages/ffx-parser-isbn/build
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+
+pkg=ffx-parser-isbn
+pkgDir=packages/${pkg}
+outputDir=dist/out-tsc/packages
+
+tsc -b ${pkgDir}/tsconfig.lib.json && \
+  cp ${pkgDir}/package.json ${pkgDir}/README.md ${pkgDir}/CHANGELOG.md ${outputDir}/${pkg}/
+

--- a/packages/ffx-parser-isbn/eslint.config.js
+++ b/packages/ffx-parser-isbn/eslint.config.js
@@ -1,0 +1,45 @@
+const { FlatCompat } = require("@eslint/eslintrc");
+const js = require("@eslint/js");
+
+const baseConfig = require("../../eslint.config.js");
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+});
+
+module.exports = [
+  ...baseConfig,
+  {
+    files: ["packages/ffx-parser-isbn/**/*.{js,ts,mjs,mts}"],
+    rules: {},
+  },
+  {
+    files: ["packages/ffx-parser-isbn/**/*.js"],
+    rules: {},
+  },
+  {
+    files: ["packages/ffx-parser-isbn/**/*.ts"],
+    rules: {},
+  },
+  {
+    files: ["packages/ffx-parser-isbn/**/*.mjs"],
+    rules: {},
+  },
+  {
+    files: ["packages/ffx-parser-isbn/**/*.mts"],
+    rules: {},
+  },
+  ...compat.config({ parser: "jsonc-eslint-parser" }).map((config) => ({
+    ...config,
+    files: ["packages/ffx-parser-isbn/**/*.json"],
+    rules: {
+      "@nx/dependency-checks": [
+        "error",
+        {
+          ignoredFiles: ["{projectRoot}/vite.config.{js,ts,mjs,mts}"],
+        },
+      ],
+    },
+  })),
+];

--- a/packages/ffx-parser-isbn/package.json
+++ b/packages/ffx-parser-isbn/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@oberan/ffx-parser-isbn",
+  "description": "Change me!!",
+  "version": "0.1.0",
+  "license": "BSD-3-Clause",
+  "keywords": [
+    "change me"
+  ],
+  "author": "Oberan (https://oberan.dev)",
+  "homepage": "https://github.com/oberandev/ffx#readme",
+  "bugs": {
+    "url": "https://github.com/oberandev/ffx/issues"
+  },
+  "engines": {
+    "node": ">= 18"
+  },
+  "type": "module",
+  "main": "./src/index.mts",
+  "typings": "./src/index.d.mts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.mts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oberandev/ffx.git",
+    "directory": "packages/ffx-orm"
+  },
+  "dependencies": {
+    "fp-ts": "^2.16.1",
+    "parser-ts": "^0.7.0"
+  }
+}

--- a/packages/ffx-parser-isbn/project.json
+++ b/packages/ffx-parser-isbn/project.json
@@ -1,0 +1,40 @@
+{
+  "name": "ffx-parser-isbn",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/ffx-parser-isbn/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "command": "packages/ffx-parser-isbn/build"
+    },
+    "format:check": {
+      "command": "prettier packages/ffx-parser-isbn/**/*.{js,mts,ts} --check"
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "eslint packages/ffx-parser-isbn"
+      }
+    },
+    "publish": {
+      "command": "node tools/scripts/publish.mjs ffx-parser-isbn {args.ver} {args.tag}",
+      "dependsOn": ["build"]
+    },
+    "test": {
+      "executor": "@nx/vite:test",
+      "outputs": ["{options.reportsDirectory}"],
+      "options": {
+        "coverage": true,
+        "passWithNoTests": false,
+        "reporters": ["default"],
+        "reportsDirectory": "../../coverage/packages/ffx-parser-isbn"
+      },
+      "configurations": {
+        "watch": {
+          "watch": true
+        }
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/ffx-parser-isbn/src/index.ts
+++ b/packages/ffx-parser-isbn/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./lib/parser.mjs";

--- a/packages/ffx-parser-isbn/src/lib/parser.mts
+++ b/packages/ffx-parser-isbn/src/lib/parser.mts
@@ -1,0 +1,174 @@
+import * as E from "fp-ts/Either";
+import { pipe } from "fp-ts/function";
+import * as O from "fp-ts/Option";
+import * as RA from "fp-ts/ReadonlyArray";
+import * as Str from "fp-ts/string";
+import { Iso } from "monocle-ts";
+import * as N from "newtype-ts";
+import * as C from "parser-ts/char";
+import * as P from "parser-ts/Parser";
+import { ParseResult } from "parser-ts/ParseResult";
+import * as S from "parser-ts/string";
+
+// ==================
+//       Types
+// ==================
+
+export interface ISBN extends N.Newtype<{ readonly ISBN: unique symbol }, string> {}
+
+export const isoISBN: Iso<ISBN, string> = N.iso<ISBN>();
+
+// ==================
+//       Main
+// ==================
+
+const digit = C.digit;
+
+const digitOrHyphen = C.oneOf("0123456789-");
+
+export function runParser(input: string): ParseResult<string, string> {
+  const parser = pipe(
+    digit,
+    P.bindTo("d1"),
+    P.bind("rest", () => S.many1(digitOrHyphen)),
+    P.apFirst(P.eof()),
+    P.map((ds) => pipe(Object.values(ds).join(""))),
+  );
+
+  return S.run(input)(parser);
+}
+
+/**
+ * Parse a string into a possible isbn10 or isbn13.
+ *
+ * @example
+ *
+ * ```ts
+ * import { parse } from "@oberan/ffx-parser-isbn";
+ *
+ * const result = parse("978-3-16-148410-0");
+ * ```
+ *
+ * @since 0.1.0
+ */
+export function parse(input: string): E.Either<string, ISBN> {
+  return pipe(
+    runParser(input),
+    E.matchW(
+      ({ expected, input }) => {
+        const customErrorMsg: string = `Expected ${expected.join(" ")} at position ${
+          input.cursor + 1
+        } but found "${input.buffer[input.cursor]}"`;
+
+        return E.left(customErrorMsg);
+      },
+      ({ value }) => {
+        return isValid(value)
+          ? E.right(isoISBN.wrap(value))
+          : E.left("ISBN failed checksum validation");
+      },
+    ),
+  );
+}
+
+// ==================
+//      Helpers
+// ==================
+
+/**
+ *
+ *
+ * @example
+ *
+ * ```ts
+ * import { isValid } from "@oberan/ffx-parser-isbn";
+ *
+ * isValid(isbn);
+ * ```
+ *
+ * @since 0.1.0
+ */
+function isValid(input: string): boolean {
+  const cleaned = pipe(
+    input,
+    Str.split(""),
+    RA.filter((char) => char !== "-"),
+  );
+
+  if (RA.size(cleaned) === 10) {
+    // (x1 + 2*x2 + 3*x3 + 4*x4 + 5*x5 + 6*x6 + 7*x7 + 8*x8 + 9*x9 + 10*x10) === 0 modulo 11
+    return pipe(
+      cleaned,
+      RA.map((str: string) => Number(str)),
+      RA.reduceWithIndex<number, number>(0, (idx, acc, cur) => {
+        return acc + (idx + 1) * cur;
+      }),
+      (total) => total % 11 === 0,
+    );
+  }
+
+  if (RA.size(cleaned) === 13) {
+    // (x1 + 3*x2 + x3 + 3*x4 + x5 + 3*x6 + x7 + 3*x8 + x9 + 3*x10 + x11 + 3*x12 + x13) === 0 modulo 10
+    return pipe(
+      cleaned,
+      RA.map((str: string) => Number(str)),
+      RA.reduceWithIndex<number, number>(0, (idx, acc, cur) => {
+        return acc + (idx % 2 === 0 ? 1 : 3) * cur;
+      }),
+      (total) => total % 10 === 0,
+    );
+  }
+
+  return false;
+}
+
+/**
+ * Convert a 10-digit ISBN to a 13-digit ISBN.
+ *
+ * @example
+ *
+ * ```ts
+ * import { upConvert } from "@oberan/ffx-parser-isbn";
+ *
+ * upConvert(isbn);
+ * ```
+ *
+ * @since 0.1.0
+ */
+export function upConvert(input: ISBN): ISBN {
+  return isoISBN.modify((isbn) => Str.Monoid.concat("978-", isbn))(input);
+}
+
+/**
+ * Convert a 13-digit ISBN to a 10-digit ISBN.
+ *
+ * @example
+ *
+ * ```ts
+ * import { downConvert } from "@oberan/ffx-parser-isbn";
+ *
+ * downConvert(isbn);
+ * ```
+ *
+ * @since 0.1.0
+ */
+export function downConvert(input: ISBN): O.Option<ISBN> {
+  return O.some(input);
+}
+
+/**
+ * Unwrap an ISBN type.
+ *
+ * @example
+ *
+ * ```ts
+ * import { unwrap } from "@oberan/ffx-parser-isbn";
+ *
+ * unwrap(isbn);
+ * ```
+ *
+ * @since 0.1.0
+ */
+export function unwrap(isbn: ISBN): string {
+  return isoISBN.unwrap(isbn);
+}

--- a/packages/ffx-parser-isbn/src/lib/parser.mts
+++ b/packages/ffx-parser-isbn/src/lib/parser.mts
@@ -1,5 +1,6 @@
 import * as E from "fp-ts/Either";
 import { pipe } from "fp-ts/function";
+import * as O from "fp-ts/Option";
 import * as RA from "fp-ts/ReadonlyArray";
 import * as RNEA from "fp-ts/ReadonlyNonEmptyArray";
 import * as Str from "fp-ts/string";
@@ -70,10 +71,10 @@ export function parse(input: string): E.Either<string, ISBN> {
         return E.left(customErrorMsg);
       },
       ({ value }) => {
-        const cleaned = Str.replace(/\-/g, "")(value);
+        const digits: string = Str.replace(/\-/g, "")(value);
 
-        return isValid(cleaned)
-          ? Str.size(cleaned) === 10
+        return isValid(digits)
+          ? Str.size(digits) === 10
             ? E.right({ _tag: "isbn10", value })
             : E.right({ _tag: "isbn13", value })
           : E.left("ISBN failed checksum validation");
@@ -92,33 +93,25 @@ export function parse(input: string): E.Either<string, ISBN> {
  * @internal
  */
 function isValid(input: string): boolean {
-  const cleaned = pipe(input, Str.replace(/\-/g, ""), Str.split("")); // returns RNEA
+  const cleaned = pipe(input, Str.replace(/\-/g, ""), Str.split(""));
 
-  if (cleaned.length === 10) {
-    // (x1 + 2*x2 + 3*x3 + 4*x4 + 5*x5 + 6*x6 + 7*x7 + 8*x8 + 9*x9 + 10*x10) === 0 modulo 11
-    return pipe(
-      cleaned,
-      RNEA.map((str: string) => Number(str)),
-      RNEA.reduceWithIndex<number, number>(0, (idx, acc, cur) => {
-        return acc + (idx + 1) * cur;
-      }),
-      (total) => total % 11 === 0,
-    );
-  }
-
-  if (cleaned.length === 13) {
-    // (x1 + 3*x2 + x3 + 3*x4 + x5 + 3*x6 + x7 + 3*x8 + x9 + 3*x10 + x11 + 3*x12 + x13) === 0 modulo 10
-    return pipe(
-      cleaned,
-      RNEA.map((str: string) => Number(str)),
-      RNEA.reduceWithIndex<number, number>(0, (idx, acc, cur) => {
-        return acc + (idx % 2 === 0 ? 1 : 3) * cur;
-      }),
-      (total) => total % 10 === 0,
-    );
-  }
-
-  return false;
+  return cleaned.length === 10
+    ? pipe(
+        cleaned,
+        RNEA.map((str: string) => Number(str)),
+        RNEA.reduceWithIndex<number, number>(0, (idx, acc, cur) => {
+          return acc + (idx + 1) * cur;
+        }),
+        (total) => total % 11 === 0,
+      )
+    : pipe(
+        cleaned,
+        RNEA.map((str: string) => Number(str)),
+        RNEA.reduceWithIndex<number, number>(0, (idx, acc, cur) => {
+          return acc + (idx % 2 === 0 ? 1 : 3) * cur;
+        }),
+        (total) => total % 10 === 0,
+      );
 }
 
 /**
@@ -126,8 +119,8 @@ function isValid(input: string): boolean {
  *
  * @internal
  */
-export function calculateChecksumDigit(digits: ReadonlyArray<number>): number {
-  return RA.size(digits) === 10
+function calculateChecksumDigit(digits: ReadonlyArray<number>): number {
+  return RA.size(digits) === 9
     ? pipe(
         digits,
         RA.reverse,
@@ -163,21 +156,24 @@ export function upConvert(input: ISBN): ISBN {
     .with({ _tag: "isbn10" }, (isbn): ISBN13 => {
       const maybeHyphen: string = Str.includes("-")(isbn.value) ? "-" : "";
 
-      const digits: ReadonlyArray<number> = pipe(
+      const newChecksum: number = pipe(
         Str.Monoid.concat("978", isbn.value),
         Str.replace(/\-/g, ""),
         Str.split(""),
         (ds) => RNEA.init(ds),
         RA.map((str: string) => Number(str)),
+        (digits) => calculateChecksumDigit(digits),
       );
 
-      const checksumDigit: number = calculateChecksumDigit(digits);
-
-      const digitsAllButLast: string = Str.slice(0, Str.size(isbn.value) - 1)(isbn.value);
+      const isbn13WithoutChecksum: string = pipe(
+        isbn.value,
+        Str.slice(0, Str.size(isbn.value) - 1),
+        (str) => `978${maybeHyphen}${str}`,
+      );
 
       return {
         _tag: "isbn13",
-        value: `978${maybeHyphen}${digitsAllButLast}${checksumDigit}`,
+        value: `${isbn13WithoutChecksum}${newChecksum}`,
       };
     })
     .with({ _tag: "isbn13" }, (isbn): ISBN13 => isbn)
@@ -197,16 +193,32 @@ export function upConvert(input: ISBN): ISBN {
  *
  * @since 0.1.0
  */
-export function downConvert(input: ISBN): ISBN {
+export function downConvert(input: ISBN): O.Option<ISBN> {
   return match(input)
-    .with({ _tag: "isbn10" }, (isbn): ISBN10 => isbn)
-    .with({ _tag: "isbn13" }, (): ISBN10 => {
-      // remove "978" if it exists
-      // recalculate checksum digit and append
-      return {
+    .with({ _tag: "isbn10" }, (isbn): O.Option<ISBN> => O.some(isbn))
+    .with({ _tag: "isbn13" }, (isbn): O.Option<ISBN> => {
+      if (!Str.startsWith("978")(isbn.value)) {
+        return O.none;
+      }
+
+      const cleaned: string = pipe(isbn.value, Str.replace(/^978\-?/g, ""));
+
+      const newChecksum: number = pipe(
+        cleaned,
+        Str.replace(/\-/g, ""),
+        Str.split(""),
+        (ds) => RNEA.init(ds),
+        RA.map((str: string) => Number(str)),
+        (digits) => calculateChecksumDigit(digits),
+      );
+
+      const isbn10WithoutChecksum: string = pipe(cleaned, Str.slice(0, Str.size(cleaned) - 1));
+
+      return O.some({
         _tag: "isbn10",
-        value: input.value,
-      };
+        value: `${isbn10WithoutChecksum}${newChecksum}`,
+      });
     })
+
     .exhaustive();
 }

--- a/packages/ffx-parser-isbn/src/lib/parser.mts
+++ b/packages/ffx-parser-isbn/src/lib/parser.mts
@@ -1,22 +1,29 @@
 import * as E from "fp-ts/Either";
 import { pipe } from "fp-ts/function";
-import * as O from "fp-ts/Option";
 import * as RA from "fp-ts/ReadonlyArray";
+import * as RNEA from "fp-ts/ReadonlyNonEmptyArray";
 import * as Str from "fp-ts/string";
-import { Iso } from "monocle-ts";
-import * as N from "newtype-ts";
 import * as C from "parser-ts/char";
 import * as P from "parser-ts/Parser";
 import { ParseResult } from "parser-ts/ParseResult";
 import * as S from "parser-ts/string";
+import { match } from "ts-pattern";
 
 // ==================
 //       Types
 // ==================
 
-export interface ISBN extends N.Newtype<{ readonly ISBN: unique symbol }, string> {}
+interface ISBN10 {
+  readonly _tag: "isbn10";
+  readonly value: string;
+}
 
-export const isoISBN: Iso<ISBN, string> = N.iso<ISBN>();
+interface ISBN13 {
+  readonly _tag: "isbn13";
+  readonly value: string;
+}
+
+type ISBN = ISBN10 | ISBN13;
 
 // ==================
 //       Main
@@ -63,8 +70,12 @@ export function parse(input: string): E.Either<string, ISBN> {
         return E.left(customErrorMsg);
       },
       ({ value }) => {
-        return isValid(value)
-          ? E.right(isoISBN.wrap(value))
+        const cleaned = Str.replace(/\-/g, "")(value);
+
+        return isValid(cleaned)
+          ? Str.size(cleaned) === 10
+            ? E.right({ _tag: "isbn10", value })
+            : E.right({ _tag: "isbn13", value })
           : E.left("ISBN failed checksum validation");
       },
     ),
@@ -76,43 +87,31 @@ export function parse(input: string): E.Either<string, ISBN> {
 // ==================
 
 /**
+ * Perform modular arithmetic to verify a given input can be considered a valid ISBN.
  *
- *
- * @example
- *
- * ```ts
- * import { isValid } from "@oberan/ffx-parser-isbn";
- *
- * isValid(isbn);
- * ```
- *
- * @since 0.1.0
+ * @internal
  */
 function isValid(input: string): boolean {
-  const cleaned = pipe(
-    input,
-    Str.split(""),
-    RA.filter((char) => char !== "-"),
-  );
+  const cleaned = pipe(input, Str.replace(/\-/g, ""), Str.split("")); // returns RNEA
 
-  if (RA.size(cleaned) === 10) {
+  if (cleaned.length === 10) {
     // (x1 + 2*x2 + 3*x3 + 4*x4 + 5*x5 + 6*x6 + 7*x7 + 8*x8 + 9*x9 + 10*x10) === 0 modulo 11
     return pipe(
       cleaned,
-      RA.map((str: string) => Number(str)),
-      RA.reduceWithIndex<number, number>(0, (idx, acc, cur) => {
+      RNEA.map((str: string) => Number(str)),
+      RNEA.reduceWithIndex<number, number>(0, (idx, acc, cur) => {
         return acc + (idx + 1) * cur;
       }),
       (total) => total % 11 === 0,
     );
   }
 
-  if (RA.size(cleaned) === 13) {
+  if (cleaned.length === 13) {
     // (x1 + 3*x2 + x3 + 3*x4 + x5 + 3*x6 + x7 + 3*x8 + x9 + 3*x10 + x11 + 3*x12 + x13) === 0 modulo 10
     return pipe(
       cleaned,
-      RA.map((str: string) => Number(str)),
-      RA.reduceWithIndex<number, number>(0, (idx, acc, cur) => {
+      RNEA.map((str: string) => Number(str)),
+      RNEA.reduceWithIndex<number, number>(0, (idx, acc, cur) => {
         return acc + (idx % 2 === 0 ? 1 : 3) * cur;
       }),
       (total) => total % 10 === 0,
@@ -123,7 +122,31 @@ function isValid(input: string): boolean {
 }
 
 /**
- * Convert a 10-digit ISBN to a 13-digit ISBN.
+ * Perform modular arithmetic to calculate the checksum digit.
+ *
+ * @internal
+ */
+export function calculateChecksumDigit(digits: ReadonlyArray<number>): number {
+  return RA.size(digits) === 10
+    ? pipe(
+        digits,
+        RA.reverse,
+        RA.reduceWithIndex<number, number>(0, (idx, acc, cur) => {
+          return acc + (idx + 2) * cur;
+        }),
+        (total) => (11 - (total % 11)) % 11,
+      )
+    : pipe(
+        digits,
+        RA.reduceWithIndex<number, number>(0, (idx, acc, cur) => {
+          return acc + (idx % 2 === 0 ? 1 : 3) * cur;
+        }),
+        (total) => 10 - (total % 10),
+      );
+}
+
+/**
+ * Safely convert a 10-digit ISBN to a 13-digit ISBN.
  *
  * @example
  *
@@ -136,11 +159,33 @@ function isValid(input: string): boolean {
  * @since 0.1.0
  */
 export function upConvert(input: ISBN): ISBN {
-  return isoISBN.modify((isbn) => Str.Monoid.concat("978-", isbn))(input);
+  return match(input)
+    .with({ _tag: "isbn10" }, (isbn): ISBN13 => {
+      const maybeHyphen: string = Str.includes("-")(isbn.value) ? "-" : "";
+
+      const digits: ReadonlyArray<number> = pipe(
+        Str.Monoid.concat("978", isbn.value),
+        Str.replace(/\-/g, ""),
+        Str.split(""),
+        (ds) => RNEA.init(ds),
+        RA.map((str: string) => Number(str)),
+      );
+
+      const checksumDigit: number = calculateChecksumDigit(digits);
+
+      const digitsAllButLast: string = Str.slice(0, Str.size(isbn.value) - 1)(isbn.value);
+
+      return {
+        _tag: "isbn13",
+        value: `978${maybeHyphen}${digitsAllButLast}${checksumDigit}`,
+      };
+    })
+    .with({ _tag: "isbn13" }, (isbn): ISBN13 => isbn)
+    .exhaustive();
 }
 
 /**
- * Convert a 13-digit ISBN to a 10-digit ISBN.
+ * Safely convert a 13-digit ISBN to a 10-digit ISBN.
  *
  * @example
  *
@@ -152,23 +197,16 @@ export function upConvert(input: ISBN): ISBN {
  *
  * @since 0.1.0
  */
-export function downConvert(input: ISBN): O.Option<ISBN> {
-  return O.some(input);
-}
-
-/**
- * Unwrap an ISBN type.
- *
- * @example
- *
- * ```ts
- * import { unwrap } from "@oberan/ffx-parser-isbn";
- *
- * unwrap(isbn);
- * ```
- *
- * @since 0.1.0
- */
-export function unwrap(isbn: ISBN): string {
-  return isoISBN.unwrap(isbn);
+export function downConvert(input: ISBN): ISBN {
+  return match(input)
+    .with({ _tag: "isbn10" }, (isbn): ISBN10 => isbn)
+    .with({ _tag: "isbn13" }, (): ISBN10 => {
+      // remove "978" if it exists
+      // recalculate checksum digit and append
+      return {
+        _tag: "isbn10",
+        value: input.value,
+      };
+    })
+    .exhaustive();
 }

--- a/packages/ffx-parser-isbn/test/parser.spec.mts
+++ b/packages/ffx-parser-isbn/test/parser.spec.mts
@@ -2,7 +2,7 @@ import * as E from "fp-ts/Either";
 import { pipe } from "fp-ts/function";
 import * as RA from "fp-ts/ReadonlyArray";
 
-import { parse, runParser, upConvert } from "../src/lib/parser.mjs";
+import { downConvert, parse, runParser, upConvert } from "../src/lib/parser.mjs";
 
 describe("ISBN", () => {
   describe("runParser()", () => {
@@ -21,6 +21,22 @@ describe("ISBN", () => {
             buffer: ["0", "-", "3", "0", "6", "-", "4", "0", "6", "1", "5", "-", "2"],
             cursor: 0,
           },
+        },
+      });
+    });
+
+    it("should handle invalid ISBN-10", () => {
+      const result = runParser("-306-40615-2");
+
+      expect(result).toStrictEqual({
+        _tag: "Left",
+        left: {
+          input: {
+            buffer: ["-", "3", "0", "6", "-", "4", "0", "6", "1", "5", "-", "2"],
+            cursor: 0,
+          },
+          expected: ["a digit"],
+          fatal: false,
         },
       });
     });
@@ -110,6 +126,24 @@ describe("ISBN", () => {
       );
     });
 
+    it("should handle invalid parse()", () => {
+      const result = parse("-99921-58-10-6");
+
+      expect(result).toStrictEqual({
+        _tag: "Left",
+        left: `Expected a digit at position 1 but found "-"`,
+      });
+    });
+
+    it("should handle ISBN-10 failed checksum check", () => {
+      const result = parse("99921-58-10-6");
+
+      expect(result).toStrictEqual({
+        _tag: "Left",
+        left: "ISBN failed checksum validation",
+      });
+    });
+
     it("should handle valid ISBN-13", () => {
       pipe(
         [
@@ -118,7 +152,6 @@ describe("ISBN", () => {
           "978-1-4028-9462-6",
           "9781681972718",
           "9781861973719",
-          // "0-85131-041-9", // => 978-0-85131-041-1 => verify that adding 978 doesn't always work for upConvert
         ],
         RA.map((input) => {
           const result = parse(input);
@@ -134,7 +167,16 @@ describe("ISBN", () => {
       );
     });
 
-    it.only("should handle upConvert()", () => {
+    it("should handle ISBN-13 failed checksum check", () => {
+      const result = parse("978-0-306-40615-6");
+
+      expect(result).toStrictEqual({
+        _tag: "Left",
+        left: "ISBN failed checksum validation",
+      });
+    });
+
+    it("should handle upConvert()", () => {
       pipe(
         [
           ["99921-58-10-7", "978-99921-58-10-4"],
@@ -148,7 +190,7 @@ describe("ISBN", () => {
           ["9386954214", "9789386954213"],
           // ["0943396042", "978094339604X"],
         ],
-        RA.map(([input, upconverted]) => {
+        RA.map(([input, converted]) => {
           const result = pipe(
             parse(input),
             E.map((isbn) => upConvert(isbn)),
@@ -158,11 +200,54 @@ describe("ISBN", () => {
             _tag: "Right",
             right: {
               _tag: "isbn13",
-              value: upconverted,
+              value: converted,
             },
           });
         }),
       );
+    });
+
+    it("should handle downConvert()", () => {
+      pipe(
+        [
+          ["978-99921-58-10-4", "99921-58-10-7"],
+          ["978-9971-5-0210-2", "9971-5-0210-0"],
+          ["978-960-425-059-2", "960-425-059-0"],
+          ["978-80-902734-1-2", "80-902734-1-6"],
+          ["978-85-359-0277-8", "85-359-0277-5"],
+          ["978-1-84356-028-9", "1-84356-028-3"],
+          ["978-0-684-84328-5", "0-684-84328-5"],
+          ["978-0-85131-041-1", "0-85131-041-9"],
+          ["9789386954213", "9386954214"],
+          // ["978094339604X", "0943396042"],
+        ],
+        RA.map(([input, converted]) => {
+          const result = pipe(
+            parse(input),
+            E.chain((isbn) => E.fromOption(() => "No equivalent")(downConvert(isbn))),
+          );
+
+          expect(result).toStrictEqual({
+            _tag: "Right",
+            right: {
+              _tag: "isbn10",
+              value: converted,
+            },
+          });
+        }),
+      );
+    });
+
+    it("should handle downConvert() failure", () => {
+      const result = pipe(
+        parse("1239386954211"),
+        E.chain((isbn) => E.fromOption(() => "No equivalent")(downConvert(isbn))),
+      );
+
+      expect(result).toStrictEqual({
+        _tag: "Left",
+        left: "No equivalent",
+      });
     });
   });
 });

--- a/packages/ffx-parser-isbn/test/parser.spec.mts
+++ b/packages/ffx-parser-isbn/test/parser.spec.mts
@@ -1,0 +1,129 @@
+import { pipe } from "fp-ts/function";
+import * as RA from "fp-ts/ReadonlyArray";
+
+import { parse, runParser } from "../src/lib/parser.mjs";
+
+describe("ISBN", () => {
+  describe("runParser()", () => {
+    it("should handle valid ISBN-10", () => {
+      const result = runParser("0-306-40615-2");
+
+      expect(result).toStrictEqual({
+        _tag: "Right",
+        right: {
+          value: "0-306-40615-2",
+          next: {
+            buffer: ["0", "-", "3", "0", "6", "-", "4", "0", "6", "1", "5", "-", "2"],
+            cursor: 13,
+          },
+          start: {
+            buffer: ["0", "-", "3", "0", "6", "-", "4", "0", "6", "1", "5", "-", "2"],
+            cursor: 0,
+          },
+        },
+      });
+    });
+
+    it("should handle valid ISBN-13", () => {
+      const result = runParser("978-0-306-40615-7");
+
+      expect(result).toStrictEqual({
+        _tag: "Right",
+        right: {
+          value: "978-0-306-40615-7",
+          next: {
+            buffer: [
+              "9",
+              "7",
+              "8",
+              "-",
+              "0",
+              "-",
+              "3",
+              "0",
+              "6",
+              "-",
+              "4",
+              "0",
+              "6",
+              "1",
+              "5",
+              "-",
+              "7",
+            ],
+            cursor: 17,
+          },
+          start: {
+            buffer: [
+              "9",
+              "7",
+              "8",
+              "-",
+              "0",
+              "-",
+              "3",
+              "0",
+              "6",
+              "-",
+              "4",
+              "0",
+              "6",
+              "1",
+              "5",
+              "-",
+              "7",
+            ],
+            cursor: 0,
+          },
+        },
+      });
+    });
+  });
+
+  describe("parse()", () => {
+    it("should handle valid ISBN-10", () => {
+      pipe(
+        [
+          "99921-58-10-7",
+          "9971-5-0210-0",
+          "960-425-059-0",
+          "80-902734-1-6",
+          "85-359-0277-5",
+          "1-84356-028-3",
+          "0-684-84328-5",
+          "0-85131-041-9",
+          "93-86954-21-4",
+          "0-943396-04-2",
+        ],
+        RA.map((input) => {
+          const result = parse(input);
+
+          expect(result).toStrictEqual({
+            _tag: "Right",
+            right: input,
+          });
+        }),
+      );
+    });
+
+    it("should handle valid ISBN-13", () => {
+      pipe(
+        [
+          "978-0-306-40615-7",
+          "978-1-56619-909-4",
+          "978-1-4028-9462-6",
+          "9781681972718",
+          "9781861973719",
+        ],
+        RA.map((input) => {
+          const result = parse(input);
+
+          expect(result).toStrictEqual({
+            _tag: "Right",
+            right: input,
+          });
+        }),
+      );
+    });
+  });
+});

--- a/packages/ffx-parser-isbn/tsconfig.json
+++ b/packages/ffx-parser-isbn/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "strict": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/ffx-parser-isbn/tsconfig.lib.json
+++ b/packages/ffx-parser-isbn/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "../../dist/out-tsc",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.mts"],
+  "exclude": ["vite.config.ts", "test/**/*.spec.mts"]
+}

--- a/packages/ffx-parser-isbn/tsconfig.spec.json
+++ b/packages/ffx-parser-isbn/tsconfig.spec.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
+  },
+  "include": ["vite.config.ts", "test/**/*.spec.mts", "src/**/*.d.mts"]
+}

--- a/packages/ffx-parser-isbn/tsdoc.json
+++ b/packages/ffx-parser-isbn/tsdoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["../../tsdoc.base.json"]
+}

--- a/packages/ffx-parser-isbn/vite.config.ts
+++ b/packages/ffx-parser-isbn/vite.config.ts
@@ -1,0 +1,26 @@
+/// <reference types='vitest' />
+import { nxViteTsPaths } from "@nx/vite/plugins/nx-tsconfig-paths.plugin";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  cacheDir: "../../node_modules/.vite/ffx-parser-isbn",
+
+  plugins: [nxViteTsPaths()],
+
+  // Uncomment this if you are using workers.
+  // worker: {
+  //  plugins: [ nxViteTsPaths() ],
+  // },
+
+  test: {
+    cache: {
+      dir: "../../node_modules/.vitest",
+    },
+    coverage: {
+      provider: "v8",
+    },
+    environment: "node",
+    globals: true,
+    include: ["test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}"],
+  },
+});

--- a/packages/ffx-parser-uuid/src/lib/parser.mts
+++ b/packages/ffx-parser-uuid/src/lib/parser.mts
@@ -91,7 +91,7 @@ export function parse(input: string): E.Either<string, UUID> {
 // ==================
 
 /**
- *  Opinionated format - convert to lowercase.
+ * Opinionated format - convert to lowercase.
  *
  * @example
  *
@@ -108,7 +108,7 @@ export function format(uuid: UUID): UUID {
 }
 
 /**
- *  Test for the special case of the "max" UUID - `FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF`
+ * Test for the special case of the "max" UUID - `FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF`
  *
  * @example
  *
@@ -125,7 +125,7 @@ export function isMax(uuid: UUID): boolean {
 }
 
 /**
- *  Test for the special case of the "nil" UUID - `00000000-0000-0000-0000-000000000000`
+ * Test for the special case of the "nil" UUID - `00000000-0000-0000-0000-000000000000`
  *
  * @example
  *
@@ -142,7 +142,7 @@ export function isNil(uuid: UUID): boolean {
 }
 
 /**
- *  Unwrap a UUID type.
+ * Unwrap an UUID type.
  *
  * @example
  *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,7 +227,14 @@ importers:
 
   packages/ffx-parser-ip: {}
 
-  packages/ffx-parser-isbn: {}
+  packages/ffx-parser-isbn:
+    dependencies:
+      fp-ts:
+        specifier: ^2.16.1
+        version: 2.16.1
+      parser-ts:
+        specifier: ^0.7.0
+        version: 0.7.0(fp-ts@2.16.1)
 
   packages/ffx-parser-mac:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,8 @@ importers:
 
   packages/ffx-parser-ip: {}
 
+  packages/ffx-parser-isbn: {}
+
   packages/ffx-parser-mac:
     dependencies:
       fp-ts:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,6 +18,7 @@
       "@ffx/parser-address-geocodio": ["packages/ffx-parser-address-geocodio/src/index.mts"],
       "@ffx/parser-boolean": ["packages/ffx-parser-boolean/src/index.mts"],
       "@ffx/parser-ip": ["packages/ffx-parser-ip/src/index.mts"],
+      "@ffx/parser-isbn": ["packages/ffx-parser-isbn/src/index.mts"],
       "@ffx/parser-mac": ["packages/ffx-parser-mac/src/index.mts"],
       "@ffx/parser-uuid": ["packages/ffx-parser-uuid/src/index.mts"]
     },


### PR DESCRIPTION
# Description

Add initial ISBN-10/13 parser. Doesn't handle "X" as checksum digit yet, but that will come later. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests (when necessary).
- [x] I have documented the code with examples and TSDoc.
