### PR TITLE
feat(ffx-api): add sheets and workbooks endpoints

### DIFF
--- a/packages/ffx-api/package.json
+++ b/packages/ffx-api/package.json
@@ -31,6 +31,8 @@
     "axios": "^1.5.0",
     "fp-ts": "^2.16.0",
     "io-ts": "^2.2.20",
-    "io-ts-reporters": "^2.0.0"
+    "io-ts-reporters": "^2.0.0",
+    "monocle-ts": "^2.3.13",
+    "newtype-ts": "^0.3.5"
   }
 }

--- a/packages/ffx-api/src/index.mts
+++ b/packages/ffx-api/src/index.mts
@@ -10,11 +10,10 @@ import {
 } from "./lib/agents.mjs";
 import {
   CreateDocumentInput,
-  DeleteDocumentInput,
   Document,
+  DocumentId,
   Documents,
   SpaceId,
-  GetDocumentInput,
   UpdateDocumentInput,
   createDocument,
   deleteDocument,
@@ -34,18 +33,7 @@ import {
   listEnvironments,
   updateEnvironment,
 } from "./lib/environments.mjs";
-import {
-  CreateSheetInput,
-  Sheet,
-  SheetId,
-  Sheets,
-  UpdateSheetInput,
-  createSheet,
-  deleteSheet,
-  getSheet,
-  listSheets,
-  updateSheet,
-} from "./lib/sheets.mjs";
+import { Sheet, SheetId, Sheets, deleteSheet, getSheet, listSheets } from "./lib/sheets.mjs";
 import { ApiReader, DecoderErrors, HttpError, Successful } from "./lib/types.mjs";
 import {
   CreateWorkbookInput,
@@ -72,14 +60,21 @@ interface ApiClient {
   };
   documents: {
     create: (
+      spaceId: SpaceId,
       input: CreateDocumentInput,
     ) => Promise<DecoderErrors | HttpError | Successful<Document>>;
     delete: (
-      input: DeleteDocumentInput,
+      documentId: DocumentId,
+      spaceId: SpaceId,
     ) => Promise<DecoderErrors | HttpError | Successful<{ success: boolean }>>;
-    get: (input: GetDocumentInput) => Promise<DecoderErrors | HttpError | Successful<Document>>;
+    get: (
+      documentId: DocumentId,
+      spaceId: SpaceId,
+    ) => Promise<DecoderErrors | HttpError | Successful<Document>>;
     list: (spaceId: SpaceId) => Promise<DecoderErrors | HttpError | Successful<Documents>>;
     update: (
+      documentId: DocumentId,
+      spaceId: SpaceId,
       input: UpdateDocumentInput,
     ) => Promise<DecoderErrors | HttpError | Successful<Document>>;
   };
@@ -95,17 +90,16 @@ interface ApiClient {
     ) => Promise<DecoderErrors | HttpError | Successful<Environment>>;
     list: () => Promise<DecoderErrors | HttpError | Successful<Environments>>;
     update: (
+      environmentId: EnvironmentId,
       input: UpdateEnvironmentInput,
     ) => Promise<DecoderErrors | HttpError | Successful<Environment>>;
   };
   sheets: {
-    create: (input: CreateSheetInput) => Promise<DecoderErrors | HttpError | Successful<Sheet>>;
     delete: (
       sheetId: SheetId,
     ) => Promise<DecoderErrors | HttpError | Successful<{ success: boolean }>>;
     get: (sheetId: SheetId) => Promise<DecoderErrors | HttpError | Successful<Sheet>>;
     list: () => Promise<DecoderErrors | HttpError | Successful<Sheets>>;
-    update: (input: UpdateSheetInput) => Promise<DecoderErrors | HttpError | Successful<Sheet>>;
   };
   workbooks: {
     create: (
@@ -117,6 +111,7 @@ interface ApiClient {
     get: (workbookId: WorkbookId) => Promise<DecoderErrors | HttpError | Successful<Workbook>>;
     list: () => Promise<DecoderErrors | HttpError | Successful<Workbooks>>;
     update: (
+      workbookId: WorkbookId,
       input: UpdateWorkbookInput,
     ) => Promise<DecoderErrors | HttpError | Successful<Workbook>>;
   };
@@ -141,32 +136,50 @@ export default function mkApiClient(secret: string, environmentId: EnvironmentId
       list: () => listAgents()(reader)(),
     },
     documents: {
-      create: (input) => createDocument(input)(reader)(),
-      delete: (input) => deleteDocument(input)(reader)(),
-      get: (input) => getDocument(input)(reader)(),
+      create: (spaceId, input) => createDocument(spaceId, input)(reader)(),
+      delete: (documentId, spaceId) => deleteDocument(documentId, spaceId)(reader)(),
+      get: (documentId, spaceId) => getDocument(documentId, spaceId)(reader)(),
       list: (spaceId) => listDocuments(spaceId)(reader)(),
-      update: (input) => updateDocument(input)(reader)(),
+      update: (documentId, spaceId, input) => updateDocument(documentId, spaceId, input)(reader)(),
     },
     environments: {
       create: (input) => createEnvironment(input)(reader)(),
       delete: (environmentId) => deleteEnvironment(environmentId)(reader)(),
       get: (environmentId) => getEnvironment(environmentId)(reader)(),
       list: () => listEnvironments()(reader)(),
-      update: (input) => updateEnvironment(input)(reader)(),
+      update: (environmentId, input) => updateEnvironment(environmentId, input)(reader)(),
     },
     sheets: {
-      create: (input) => createSheet(input)(reader)(),
       delete: (sheetId) => deleteSheet(sheetId)(reader)(),
       get: (sheetId) => getSheet(sheetId)(reader)(),
       list: () => listSheets()(reader)(),
-      update: (input) => updateSheet(input)(reader)(),
     },
     workbooks: {
       create: (input) => createWorkbook(input)(reader)(),
       delete: (workbookId) => deleteWorkbook(workbookId)(reader)(),
       get: (workbookId) => getWorkbook(workbookId)(reader)(),
       list: () => listWorkbooks()(reader)(),
-      update: (input) => updateWorkbook(input)(reader)(),
+      update: (workbookId, input) => updateWorkbook(workbookId, input)(reader)(),
     },
   };
 }
+
+export { Agent, Agents, AgentId, EventTopic, isoAgentId } from "./lib/agents.mjs";
+export {
+  Document,
+  Documents,
+  DocumentId,
+  SpaceId,
+  isoDocumentId,
+  isoSpaceId,
+} from "./lib/documents.mjs";
+export {
+  AccountId,
+  Environment,
+  Environments,
+  EnvironmentId,
+  isoAccountId,
+  isoEnvironmentId,
+} from "./lib/environments.mjs";
+export { Permission, Sheet, Sheets, SheetId, isoSheetId } from "./lib/sheets.mjs";
+export { Workbook, Workbooks, WorkbookId, isoWorkbookId } from "./lib/workbooks.mjs";

--- a/packages/ffx-api/src/index.mts
+++ b/packages/ffx-api/src/index.mts
@@ -1,5 +1,6 @@
 import {
   Agent,
+  AgentId,
   Agents,
   CreateAgentInput,
   createAgent,
@@ -12,6 +13,7 @@ import {
   DeleteDocumentInput,
   Document,
   Documents,
+  SpaceId,
   GetDocumentInput,
   UpdateDocumentInput,
   createDocument,
@@ -23,6 +25,7 @@ import {
 import {
   CreateEnvironmentInput,
   Environment,
+  EnvironmentId,
   Environments,
   UpdateEnvironmentInput,
   createEnvironment,
@@ -34,6 +37,7 @@ import {
 import {
   CreateSheetInput,
   Sheet,
+  SheetId,
   Sheets,
   UpdateSheetInput,
   createSheet,
@@ -47,6 +51,7 @@ import {
   CreateWorkbookInput,
   UpdateWorkbookInput,
   Workbook,
+  WorkbookId,
   Workbooks,
   createWorkbook,
   deleteWorkbook,
@@ -60,9 +65,9 @@ interface ApiClient {
   agents: {
     create: (input: CreateAgentInput) => Promise<DecoderErrors | HttpError | Successful<Agent>>;
     delete: (
-      agentId: string,
+      agentId: AgentId,
     ) => Promise<DecoderErrors | HttpError | Successful<{ success: boolean }>>;
-    get: (agentId: string) => Promise<DecoderErrors | HttpError | Successful<Agent>>;
+    get: (agentId: AgentId) => Promise<DecoderErrors | HttpError | Successful<Agent>>;
     list: () => Promise<DecoderErrors | HttpError | Successful<Agents>>;
   };
   documents: {
@@ -73,7 +78,7 @@ interface ApiClient {
       input: DeleteDocumentInput,
     ) => Promise<DecoderErrors | HttpError | Successful<{ success: boolean }>>;
     get: (input: GetDocumentInput) => Promise<DecoderErrors | HttpError | Successful<Document>>;
-    list: (spaceId: string) => Promise<DecoderErrors | HttpError | Successful<Documents>>;
+    list: (spaceId: SpaceId) => Promise<DecoderErrors | HttpError | Successful<Documents>>;
     update: (
       input: UpdateDocumentInput,
     ) => Promise<DecoderErrors | HttpError | Successful<Document>>;
@@ -83,9 +88,11 @@ interface ApiClient {
       input: CreateEnvironmentInput,
     ) => Promise<DecoderErrors | HttpError | Successful<Environment>>;
     delete: (
-      environmentId: string,
+      environmentId: EnvironmentId,
     ) => Promise<DecoderErrors | HttpError | Successful<{ success: boolean }>>;
-    get: (environmentId: string) => Promise<DecoderErrors | HttpError | Successful<Environment>>;
+    get: (
+      environmentId: EnvironmentId,
+    ) => Promise<DecoderErrors | HttpError | Successful<Environment>>;
     list: () => Promise<DecoderErrors | HttpError | Successful<Environments>>;
     update: (
       input: UpdateEnvironmentInput,
@@ -94,9 +101,9 @@ interface ApiClient {
   sheets: {
     create: (input: CreateSheetInput) => Promise<DecoderErrors | HttpError | Successful<Sheet>>;
     delete: (
-      sheetId: string,
+      sheetId: SheetId,
     ) => Promise<DecoderErrors | HttpError | Successful<{ success: boolean }>>;
-    get: (sheetId: string) => Promise<DecoderErrors | HttpError | Successful<Sheet>>;
+    get: (sheetId: SheetId) => Promise<DecoderErrors | HttpError | Successful<Sheet>>;
     list: () => Promise<DecoderErrors | HttpError | Successful<Sheets>>;
     update: (input: UpdateSheetInput) => Promise<DecoderErrors | HttpError | Successful<Sheet>>;
   };
@@ -105,9 +112,9 @@ interface ApiClient {
       input: CreateWorkbookInput,
     ) => Promise<DecoderErrors | HttpError | Successful<Workbook>>;
     delete: (
-      workbookId: string,
+      workbookId: WorkbookId,
     ) => Promise<DecoderErrors | HttpError | Successful<{ success: boolean }>>;
-    get: (workbookId: string) => Promise<DecoderErrors | HttpError | Successful<Workbook>>;
+    get: (workbookId: WorkbookId) => Promise<DecoderErrors | HttpError | Successful<Workbook>>;
     list: () => Promise<DecoderErrors | HttpError | Successful<Workbooks>>;
     update: (
       input: UpdateWorkbookInput,

--- a/packages/ffx-api/src/index.mts
+++ b/packages/ffx-api/src/index.mts
@@ -122,7 +122,7 @@ interface ApiClient {
   };
 }
 
-export default function mkApiClient(secret: string, environmentId: string): ApiClient {
+export default function mkApiClient(secret: string, environmentId: EnvironmentId): ApiClient {
   const reader: ApiReader = {
     baseUrl: "https://platform.flatfile.com/api/v1",
     environmentId,

--- a/packages/ffx-api/src/index.mts
+++ b/packages/ffx-api/src/index.mts
@@ -31,7 +31,29 @@ import {
   listEnvironments,
   updateEnvironment,
 } from "./lib/environments.mjs";
+import {
+  CreateSheetInput,
+  Sheet,
+  Sheets,
+  UpdateSheetInput,
+  createSheet,
+  deleteSheet,
+  getSheet,
+  listSheets,
+  updateSheet,
+} from "./lib/sheets.mjs";
 import { ApiReader, DecoderErrors, HttpError, Successful } from "./lib/types.mjs";
+import {
+  CreateWorkbookInput,
+  UpdateWorkbookInput,
+  Workbook,
+  Workbooks,
+  createWorkbook,
+  deleteWorkbook,
+  getWorkbook,
+  listWorkbooks,
+  updateWorkbook,
+} from "./lib/workbooks.mjs";
 import pkgJson from "../package.json"; // eslint-disable-line import/no-relative-parent-imports
 
 interface ApiClient {
@@ -69,6 +91,28 @@ interface ApiClient {
       input: UpdateEnvironmentInput,
     ) => Promise<DecoderErrors | HttpError | Successful<Environment>>;
   };
+  sheets: {
+    create: (input: CreateSheetInput) => Promise<DecoderErrors | HttpError | Successful<Sheet>>;
+    delete: (
+      sheetId: string,
+    ) => Promise<DecoderErrors | HttpError | Successful<{ success: boolean }>>;
+    get: (sheetId: string) => Promise<DecoderErrors | HttpError | Successful<Sheet>>;
+    list: () => Promise<DecoderErrors | HttpError | Successful<Sheets>>;
+    update: (input: UpdateSheetInput) => Promise<DecoderErrors | HttpError | Successful<Sheet>>;
+  };
+  workbooks: {
+    create: (
+      input: CreateWorkbookInput,
+    ) => Promise<DecoderErrors | HttpError | Successful<Workbook>>;
+    delete: (
+      workbookId: string,
+    ) => Promise<DecoderErrors | HttpError | Successful<{ success: boolean }>>;
+    get: (workbookId: string) => Promise<DecoderErrors | HttpError | Successful<Workbook>>;
+    list: () => Promise<DecoderErrors | HttpError | Successful<Workbooks>>;
+    update: (
+      input: UpdateWorkbookInput,
+    ) => Promise<DecoderErrors | HttpError | Successful<Workbook>>;
+  };
 }
 
 export default function mkApiClient(secret: string, environmentId: string): ApiClient {
@@ -102,6 +146,20 @@ export default function mkApiClient(secret: string, environmentId: string): ApiC
       get: (environmentId) => getEnvironment(environmentId)(reader)(),
       list: () => listEnvironments()(reader)(),
       update: (input) => updateEnvironment(input)(reader)(),
+    },
+    sheets: {
+      create: (input) => createSheet(input)(reader)(),
+      delete: (sheetId) => deleteSheet(sheetId)(reader)(),
+      get: (sheetId) => getSheet(sheetId)(reader)(),
+      list: () => listSheets()(reader)(),
+      update: (input) => updateSheet(input)(reader)(),
+    },
+    workbooks: {
+      create: (input) => createWorkbook(input)(reader)(),
+      delete: (workbookId) => deleteWorkbook(workbookId)(reader)(),
+      get: (workbookId) => getWorkbook(workbookId)(reader)(),
+      list: () => listWorkbooks()(reader)(),
+      update: (input) => updateWorkbook(input)(reader)(),
     },
   };
 }

--- a/packages/ffx-api/src/lib/agents.mts
+++ b/packages/ffx-api/src/lib/agents.mts
@@ -55,7 +55,7 @@ const EventTopicCodec = t.union([
   t.literal("workbook:updated"),
 ]);
 
-export const AgentCodec = t.type({
+export const AgentCodec = t.strict({
   id: t.string,
   compiler: t.literal("js"),
   source: t.string,
@@ -132,7 +132,7 @@ export function deleteAgent(
       );
     }),
     RTE.map((resp) => resp.data.data),
-    RTE.chain(decodeWith(t.type({ success: t.boolean }))),
+    RTE.chain(decodeWith(t.strict({ success: t.boolean }))),
     RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
   );
 }

--- a/packages/ffx-api/src/lib/agents.mts
+++ b/packages/ffx-api/src/lib/agents.mts
@@ -74,7 +74,7 @@ export const codecAgentId = new t.Type<AgentId, AgentId, unknown>(
   t.identity,
 );
 
-export const codecAgent = t.strict({
+export const codecAgent = t.type({
   id: codecAgentId,
   compiler: t.literal("js"),
   source: t.string,
@@ -151,7 +151,7 @@ export function deleteAgent(
       );
     }),
     RTE.map((resp) => resp.data.data),
-    RTE.chain(decodeWith(t.strict({ success: t.boolean }))),
+    RTE.chain(decodeWith(t.type({ success: t.boolean }))),
     RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
   );
 }

--- a/packages/ffx-api/src/lib/agents.mts
+++ b/packages/ffx-api/src/lib/agents.mts
@@ -4,6 +4,8 @@ import * as RT from "fp-ts/ReaderTask";
 import * as RTE from "fp-ts/ReaderTaskEither";
 import * as TE from "fp-ts/TaskEither";
 import * as t from "io-ts";
+import { Iso } from "monocle-ts";
+import { Newtype, iso } from "newtype-ts";
 
 import {
   ApiReader,
@@ -18,7 +20,7 @@ import {
 //   Runtime codecs
 // ==================
 
-const EventTopicCodec = t.union([
+const codecEventTopic = t.union([
   t.literal("agent:created"),
   t.literal("agent:deleted"),
   t.literal("agent:updated"),
@@ -55,34 +57,37 @@ const EventTopicCodec = t.union([
   t.literal("workbook:updated"),
 ]);
 
-export const AgentIdCodec = new t.Type<string, string, unknown>(
+export interface AgentId extends Newtype<{ readonly AgentId: unique symbol }, string> {}
+
+export const isoAgentId: Iso<AgentId, string> = iso<AgentId>();
+
+export const codecAgentId = new t.Type<AgentId, AgentId, unknown>(
   "AgentId",
-  (input: unknown): input is string => {
+  (input: unknown): input is AgentId => {
     return typeof input === "string" && /^us_ag_\w{8}$/g.test(input);
   },
   (input, context) => {
     return typeof input === "string" && /^us_ag_\w{8}$/g.test(input)
-      ? t.success(input)
+      ? t.success(isoAgentId.wrap(input))
       : t.failure(input, context);
   },
   t.identity,
 );
 
-export const AgentCodec = t.strict({
-  id: AgentIdCodec,
+export const codecAgent = t.strict({
+  id: codecAgentId,
   compiler: t.literal("js"),
   source: t.string,
-  topics: t.array(EventTopicCodec),
+  topics: t.array(codecEventTopic),
 });
 
 // ==================
 //       Types
 // ==================
 
-export type Agent = Readonly<t.TypeOf<typeof AgentCodec>>;
-export type AgentId = t.TypeOf<typeof AgentIdCodec>;
+export type Agent = Readonly<t.TypeOf<typeof codecAgent>>;
 export type Agents = ReadonlyArray<Agent>;
-export type EventTopic = Readonly<t.TypeOf<typeof EventTopicCodec>>;
+export type EventTopic = Readonly<t.TypeOf<typeof codecEventTopic>>;
 export type CreateAgentInput = Omit<Agent, "id">;
 
 /**
@@ -113,7 +118,7 @@ export function createAgent(
       );
     }),
     RTE.map((resp) => resp.data),
-    RTE.chain(decodeWith(AgentCodec)),
+    RTE.chain(decodeWith(codecAgent)),
     RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
   );
 }
@@ -179,7 +184,7 @@ export function getAgent(
       );
     }),
     RTE.map((resp) => resp.data.data),
-    RTE.chain(decodeWith(AgentCodec)),
+    RTE.chain(decodeWith(codecAgent)),
     RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
   );
 }
@@ -213,7 +218,7 @@ export function listAgents(): RT.ReaderTask<
       );
     }),
     RTE.map((resp) => resp.data.data),
-    RTE.chain(decodeWith(t.array(AgentCodec))),
+    RTE.chain(decodeWith(t.array(codecAgent))),
     RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
   );
 }

--- a/packages/ffx-api/src/lib/documents.mts
+++ b/packages/ffx-api/src/lib/documents.mts
@@ -60,7 +60,6 @@ export const DocumentCodec = t.strict({
 export type Document = Readonly<t.TypeOf<typeof DocumentCodec>>;
 export type DocumentId = t.TypeOf<typeof DocumentIdCodec>;
 export type Documents = ReadonlyArray<Document>;
-export type EnvironmentId = t.TypeOf<typeof EnvironmentIdCodec>;
 export type SpaceId = t.TypeOf<typeof SpaceIdCodec>;
 export type CreateDocumentInput = Pick<Document, "body" | "spaceId" | "title">;
 export type DeleteDocumentInput = Pick<Document, "id" | "spaceId">;

--- a/packages/ffx-api/src/lib/documents.mts
+++ b/packages/ffx-api/src/lib/documents.mts
@@ -18,7 +18,7 @@ import {
 //   Runtime codecs
 // ==================
 
-export const DocumentCodec = t.type({
+export const DocumentCodec = t.strict({
   id: t.string,
   body: t.string,
   environmentId: t.string,
@@ -96,7 +96,7 @@ export function deleteDocument(
       );
     }),
     RTE.map((resp) => resp.data.data),
-    RTE.chain(decodeWith(t.type({ success: t.boolean }))),
+    RTE.chain(decodeWith(t.strict({ success: t.boolean }))),
     RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
   );
 }

--- a/packages/ffx-api/src/lib/documents.mts
+++ b/packages/ffx-api/src/lib/documents.mts
@@ -56,7 +56,7 @@ export const codecSpaceId = new t.Type<SpaceId, SpaceId, unknown>(
 );
 
 export const codecDocument = t.intersection([
-  t.strict({
+  t.type({
     id: codecDocumentId,
     body: t.string,
     environmentId: codecEnvironmentId,
@@ -138,7 +138,7 @@ export function deleteDocument(
       );
     }),
     RTE.map((resp) => resp.data.data),
-    RTE.chain(decodeWith(t.strict({ success: t.boolean }))),
+    RTE.chain(decodeWith(t.type({ success: t.boolean }))),
     RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
   );
 }

--- a/packages/ffx-api/src/lib/documents.mts
+++ b/packages/ffx-api/src/lib/documents.mts
@@ -74,10 +74,8 @@ export const codecDocument = t.intersection([
 
 export type Document = Readonly<t.TypeOf<typeof codecDocument>>;
 export type Documents = ReadonlyArray<Document>;
-export type CreateDocumentInput = Pick<Document, "body" | "spaceId" | "title" | "treatments">;
-export type DeleteDocumentInput = Pick<Document, "id" | "spaceId">;
-export type GetDocumentInput = Pick<Document, "id" | "spaceId">;
-export type UpdateDocumentInput = Omit<Document, "environmentId">;
+export type CreateDocumentInput = Pick<Document, "body" | "title" | "treatments">;
+export type UpdateDocumentInput = Pick<Document, "body" | "title" | "treatments">;
 
 /**
  * Create a `Document`.
@@ -85,6 +83,7 @@ export type UpdateDocumentInput = Omit<Document, "environmentId">;
  * @since 0.1.0
  */
 export function createDocument(
+  spaceId: SpaceId,
   input: CreateDocumentInput,
 ): RT.ReaderTask<ApiReader, DecoderErrors | HttpError | Successful<Document>> {
   return pipe(
@@ -93,15 +92,11 @@ export function createDocument(
       return RTE.fromTaskEither(
         TE.tryCatch(
           () => {
-            return axios.post(
-              `${r.baseUrl}/spaces/${input.spaceId}/documents`,
-              { body: input.body, title: input.title },
-              {
-                headers: {
-                  "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
-                },
+            return axios.post(`${r.baseUrl}/spaces/${spaceId}/documents`, input, {
+              headers: {
+                "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
               },
-            );
+            });
           },
           (reason: unknown) => reason as AxiosError,
         ),
@@ -119,7 +114,8 @@ export function createDocument(
  * @since 0.1.0
  */
 export function deleteDocument(
-  input: DeleteDocumentInput,
+  documentId: DocumentId,
+  spaceId: SpaceId,
 ): RT.ReaderTask<ApiReader, DecoderErrors | HttpError | Successful<{ success: boolean }>> {
   return pipe(
     RTE.ask<ApiReader>(),
@@ -127,7 +123,7 @@ export function deleteDocument(
       return RTE.fromTaskEither(
         TE.tryCatch(
           () => {
-            return axios.delete(`${r.baseUrl}/spaces/${input.spaceId}/documents/${input.id}`, {
+            return axios.delete(`${r.baseUrl}/spaces/${spaceId}/documents/${documentId}`, {
               headers: {
                 "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
               },
@@ -149,7 +145,8 @@ export function deleteDocument(
  * @since 0.1.0
  */
 export function getDocument(
-  input: GetDocumentInput,
+  documentId: DocumentId,
+  spaceId: SpaceId,
 ): RT.ReaderTask<ApiReader, DecoderErrors | HttpError | Successful<Document>> {
   return pipe(
     RTE.ask<ApiReader>(),
@@ -157,7 +154,7 @@ export function getDocument(
       return RTE.fromTaskEither(
         TE.tryCatch(
           () => {
-            return axios.get(`${r.baseUrl}/spaces/${input.spaceId}/documents/${input.id}`, {
+            return axios.get(`${r.baseUrl}/spaces/${spaceId}/documents/${documentId}`, {
               headers: {
                 "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
               },
@@ -209,6 +206,8 @@ export function listDocuments(
  * @since 0.1.0
  */
 export function updateDocument(
+  documentId: DocumentId,
+  spaceId: SpaceId,
   input: UpdateDocumentInput,
 ): RT.ReaderTask<ApiReader, DecoderErrors | HttpError | Successful<Document>> {
   return pipe(
@@ -217,15 +216,11 @@ export function updateDocument(
       return RTE.fromTaskEither(
         TE.tryCatch(
           () => {
-            return axios.patch(
-              `${r.baseUrl}/spaces/${input.spaceId}/documents/${input.id}`,
-              { body: input.body, title: input.title },
-              {
-                headers: {
-                  "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
-                },
+            return axios.patch(`${r.baseUrl}/spaces/${spaceId}/documents/${documentId}`, input, {
+              headers: {
+                "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
               },
-            );
+            });
           },
           (reason: unknown) => reason as AxiosError,
         ),

--- a/packages/ffx-api/src/lib/environments.mts
+++ b/packages/ffx-api/src/lib/environments.mts
@@ -21,7 +21,7 @@ import {
 const AuthenticationLinkCodec = t.union([t.literal("shared_link"), t.literal("magic_link")]);
 
 export const EnvironmentCodec = t.intersection([
-  t.type({
+  t.strict({
     id: t.string,
     accountId: t.string,
     features: t.UnknownRecord,
@@ -44,7 +44,7 @@ export type Environment = Readonly<t.TypeOf<typeof EnvironmentCodec>>;
 export type Environments = ReadonlyArray<Environment>;
 export type CreateEnvironmentInput = Omit<Environment, "accountId" | "id">;
 export type UpdateEnvironmentInput = Pick<Environment, "id"> &
-  Omit<Partial<Environment>, "accountId" | "features">;
+  Partial<Omit<Environment, "accountId" | "features">>;
 
 // ==================
 //       Main
@@ -105,7 +105,7 @@ export function deleteEnvironment(
       );
     }),
     RTE.map((resp) => resp.data.data),
-    RTE.chain(decodeWith(t.type({ success: t.boolean }))),
+    RTE.chain(decodeWith(t.strict({ success: t.boolean }))),
     RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
   );
 }

--- a/packages/ffx-api/src/lib/environments.mts
+++ b/packages/ffx-api/src/lib/environments.mts
@@ -57,7 +57,7 @@ export const codecAccountId = new t.Type<AccountId, AccountId, unknown>(
 );
 
 export const codecEnvironment = t.intersection([
-  t.strict({
+  t.type({
     id: codecEnvironmentId,
     accountId: codecAccountId,
     features: t.UnknownRecord,
@@ -141,7 +141,7 @@ export function deleteEnvironment(
       );
     }),
     RTE.map((resp) => resp.data.data),
-    RTE.chain(decodeWith(t.strict({ success: t.boolean }))),
+    RTE.chain(decodeWith(t.type({ success: t.boolean }))),
     RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
   );
 }

--- a/packages/ffx-api/src/lib/environments.mts
+++ b/packages/ffx-api/src/lib/environments.mts
@@ -4,6 +4,8 @@ import * as RT from "fp-ts/ReaderTask";
 import * as RTE from "fp-ts/ReaderTaskEither";
 import * as TE from "fp-ts/TaskEither";
 import * as t from "io-ts";
+import { Iso } from "monocle-ts";
+import { Newtype, iso } from "newtype-ts";
 
 import {
   ApiReader,
@@ -18,40 +20,48 @@ import {
 //   Runtime codecs
 // ==================
 
-const AuthenticationLinkCodec = t.union([t.literal("shared_link"), t.literal("magic_link")]);
+const codecAuthenticationLink = t.union([t.literal("shared_link"), t.literal("magic_link")]);
 
-export const EnvironmentIdCodec = new t.Type<string, string, unknown>(
+export interface EnvironmentId extends Newtype<{ readonly EnvironmentId: unique symbol }, string> {}
+
+export const isoEnvironmentId: Iso<EnvironmentId, string> = iso<EnvironmentId>();
+
+export const codecEnvironmentId = new t.Type<EnvironmentId, EnvironmentId, unknown>(
   "EnvironmentId",
-  (input: unknown): input is string => {
+  (input: unknown): input is EnvironmentId => {
     return typeof input === "string" && /^us_env_\w{8}$/g.test(input);
   },
   (input, context) => {
     return typeof input === "string" && /^us_env_\w{8}$/g.test(input)
-      ? t.success(input)
+      ? t.success(isoEnvironmentId.wrap(input))
       : t.failure(input, context);
   },
   t.identity,
 );
 
-export const AccountIdCodec = new t.Type<string, string, unknown>(
+export interface AccountId extends Newtype<{ readonly AccountId: unique symbol }, string> {}
+
+export const isoAccountId: Iso<AccountId, string> = iso<AccountId>();
+
+export const codecAccountId = new t.Type<AccountId, AccountId, unknown>(
   "AccountId",
-  (input: unknown): input is string => {
+  (input: unknown): input is AccountId => {
     return typeof input === "string" && /^us_acc_\w{8}$/g.test(input);
   },
   (input, context) => {
     return typeof input === "string" && /^us_acc_\w{8}$/g.test(input)
-      ? t.success(input)
+      ? t.success(isoAccountId.wrap(input))
       : t.failure(input, context);
   },
   t.identity,
 );
 
-export const EnvironmentCodec = t.intersection([
+export const codecEnvironment = t.intersection([
   t.strict({
-    id: EnvironmentIdCodec,
-    accountId: AccountIdCodec,
+    id: codecEnvironmentId,
+    accountId: codecAccountId,
     features: t.UnknownRecord,
-    guestAuthentication: t.array(AuthenticationLinkCodec),
+    guestAuthentication: t.array(codecAuthenticationLink),
     isProd: t.boolean,
     metadata: t.UnknownRecord,
     name: t.string,
@@ -66,9 +76,7 @@ export const EnvironmentCodec = t.intersection([
 //       Types
 // ==================
 
-export type AccountId = Readonly<t.TypeOf<typeof AccountIdCodec>>;
-export type Environment = Readonly<t.TypeOf<typeof EnvironmentCodec>>;
-export type EnvironmentId = Readonly<t.TypeOf<typeof EnvironmentIdCodec>>;
+export type Environment = Readonly<t.TypeOf<typeof codecEnvironment>>;
 export type Environments = ReadonlyArray<Environment>;
 export type CreateEnvironmentInput = Omit<Environment, "accountId" | "id">;
 export type UpdateEnvironmentInput = Pick<Environment, "id"> &
@@ -103,7 +111,7 @@ export function createEnvironment(
       );
     }),
     RTE.map((resp) => resp.data.data),
-    RTE.chain(decodeWith(EnvironmentCodec)),
+    RTE.chain(decodeWith(codecEnvironment)),
     RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
   );
 }
@@ -163,7 +171,7 @@ export function getEnvironment(
       );
     }),
     RTE.map((resp) => resp.data.data),
-    RTE.chain(decodeWith(EnvironmentCodec)),
+    RTE.chain(decodeWith(codecEnvironment)),
     RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
   );
 }
@@ -194,7 +202,7 @@ export function listEnvironments(): RT.ReaderTask<
       );
     }),
     RTE.map((resp) => resp.data.data),
-    RTE.chain(decodeWith(t.array(EnvironmentCodec))),
+    RTE.chain(decodeWith(t.array(codecEnvironment))),
     RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
   );
 }
@@ -228,7 +236,7 @@ export function updateEnvironment(
       );
     }),
     RTE.map((resp) => resp.data.data),
-    RTE.chain(decodeWith(EnvironmentCodec)),
+    RTE.chain(decodeWith(codecEnvironment)),
     RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
   );
 }

--- a/packages/ffx-api/src/lib/environments.mts
+++ b/packages/ffx-api/src/lib/environments.mts
@@ -79,8 +79,7 @@ export const codecEnvironment = t.intersection([
 export type Environment = Readonly<t.TypeOf<typeof codecEnvironment>>;
 export type Environments = ReadonlyArray<Environment>;
 export type CreateEnvironmentInput = Omit<Environment, "accountId" | "id">;
-export type UpdateEnvironmentInput = Pick<Environment, "id"> &
-  Partial<Omit<Environment, "accountId" | "features">>;
+export type UpdateEnvironmentInput = Partial<Omit<Environment, "accountId" | "features" | "id">>;
 
 // ==================
 //       Main
@@ -213,6 +212,7 @@ export function listEnvironments(): RT.ReaderTask<
  * @since 0.1.0
  */
 export function updateEnvironment(
+  environmentId: EnvironmentId,
   input: UpdateEnvironmentInput,
 ): RT.ReaderTask<ApiReader, DecoderErrors | HttpError | Successful<Environment>> {
   return pipe(
@@ -221,15 +221,11 @@ export function updateEnvironment(
       return RTE.fromTaskEither(
         TE.tryCatch(
           () => {
-            return axios.patch(
-              `${r.baseUrl}/environments/${input.id}`,
-              { ...input, id: undefined },
-              {
-                headers: {
-                  "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
-                },
+            return axios.patch(`${r.baseUrl}/environments/${environmentId}`, input, {
+              headers: {
+                "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
               },
-            );
+            });
           },
           (reason: unknown) => reason as AxiosError,
         ),

--- a/packages/ffx-api/src/lib/environments.mts
+++ b/packages/ffx-api/src/lib/environments.mts
@@ -20,10 +20,36 @@ import {
 
 const AuthenticationLinkCodec = t.union([t.literal("shared_link"), t.literal("magic_link")]);
 
+export const EnvironmentIdCodec = new t.Type<string, string, unknown>(
+  "EnvironmentId",
+  (input: unknown): input is string => {
+    return typeof input === "string" && /^us_env_\w{8}$/g.test(input);
+  },
+  (input, context) => {
+    return typeof input === "string" && /^us_env_\w{8}$/g.test(input)
+      ? t.success(input)
+      : t.failure(input, context);
+  },
+  t.identity,
+);
+
+export const AccountIdCodec = new t.Type<string, string, unknown>(
+  "AccountId",
+  (input: unknown): input is string => {
+    return typeof input === "string" && /^us_acc_\w{8}$/g.test(input);
+  },
+  (input, context) => {
+    return typeof input === "string" && /^us_acc_\w{8}$/g.test(input)
+      ? t.success(input)
+      : t.failure(input, context);
+  },
+  t.identity,
+);
+
 export const EnvironmentCodec = t.intersection([
   t.strict({
-    id: t.string,
-    accountId: t.string,
+    id: EnvironmentIdCodec,
+    accountId: AccountIdCodec,
     features: t.UnknownRecord,
     guestAuthentication: t.array(AuthenticationLinkCodec),
     isProd: t.boolean,
@@ -40,7 +66,9 @@ export const EnvironmentCodec = t.intersection([
 //       Types
 // ==================
 
+export type AccountId = Readonly<t.TypeOf<typeof AccountIdCodec>>;
 export type Environment = Readonly<t.TypeOf<typeof EnvironmentCodec>>;
+export type EnvironmentId = Readonly<t.TypeOf<typeof EnvironmentIdCodec>>;
 export type Environments = ReadonlyArray<Environment>;
 export type CreateEnvironmentInput = Omit<Environment, "accountId" | "id">;
 export type UpdateEnvironmentInput = Pick<Environment, "id"> &
@@ -86,7 +114,7 @@ export function createEnvironment(
  * @since 0.1.0
  */
 export function deleteEnvironment(
-  environmentId: string,
+  environmentId: EnvironmentId,
 ): RT.ReaderTask<ApiReader, DecoderErrors | HttpError | Successful<{ success: boolean }>> {
   return pipe(
     RTE.ask<ApiReader>(),
@@ -116,7 +144,7 @@ export function deleteEnvironment(
  * @since 0.1.0
  */
 export function getEnvironment(
-  environmentId: string,
+  environmentId: EnvironmentId,
 ): RT.ReaderTask<ApiReader, DecoderErrors | HttpError | Successful<Environment>> {
   return pipe(
     RTE.ask<ApiReader>(),

--- a/packages/ffx-api/src/lib/sheets.mts
+++ b/packages/ffx-api/src/lib/sheets.mts
@@ -19,17 +19,17 @@ import {
 // ==================
 
 export const CustomActionCodec = t.intersection([
-  t.type({
+  t.strict({
     label: t.string,
   }),
   t.partial({
     confirm: t.boolean,
     description: t.string,
     icon: t.string,
-    inputForm: t.type({
+    inputForm: t.strict({
       fields: t.array(
         t.intersection([
-          t.type({
+          t.strict({
             key: t.string,
             label: t.string,
             type: t.union([
@@ -41,9 +41,9 @@ export const CustomActionCodec = t.intersection([
             ]),
           }),
           t.partial({
-            config: t.type({
+            config: t.strict({
               options: t.intersection([
-                t.type({
+                t.strict({
                   value: t.union([t.boolean, t.number, t.string]),
                 }),
                 t.partial({
@@ -56,7 +56,7 @@ export const CustomActionCodec = t.intersection([
               ]),
             }),
             constraints: t.array(
-              t.type({
+              t.strict({
                 type: t.literal("required"),
               }),
             ),
@@ -77,13 +77,13 @@ export const CustomActionCodec = t.intersection([
 ]);
 
 const FieldCodec = t.intersection([
-  t.type({
+  t.strict({
     key: t.string,
     type: t.string,
   }),
   t.partial({
     constraints: t.array(
-      t.type({
+      t.strict({
         type: t.literal("required"),
       }),
     ),
@@ -104,7 +104,7 @@ const PermissionCodec = t.union([
 ]);
 
 const SheetConfigCodec = t.intersection([
-  t.type({
+  t.strict({
     fields: t.array(FieldCodec),
     name: t.string,
   }),
@@ -120,7 +120,7 @@ const SheetConfigCodec = t.intersection([
 ]);
 
 export const SheetCodec = t.intersection([
-  t.type({
+  t.strict({
     id: t.string,
     config: SheetConfigCodec,
     createdAt: t.string,
@@ -130,7 +130,7 @@ export const SheetCodec = t.intersection([
   }),
   t.partial({
     countRecords: t.intersection([
-      t.type({
+      t.strict({
         error: t.number,
         total: t.number,
         valid: t.number,
@@ -212,7 +212,7 @@ export function deleteSheet(
       );
     }),
     RTE.map((resp) => resp.data.data),
-    RTE.chain(decodeWith(t.type({ success: t.boolean }))),
+    RTE.chain(decodeWith(t.strict({ success: t.boolean }))),
     RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
   );
 }

--- a/packages/ffx-api/src/lib/sheets.mts
+++ b/packages/ffx-api/src/lib/sheets.mts
@@ -119,9 +119,22 @@ const SheetConfigCodec = t.intersection([
   }),
 ]);
 
+export const SheetIdCodec = new t.Type<string, string, unknown>(
+  "SheetId",
+  (input: unknown): input is string => {
+    return typeof input === "string" && /^us_sh_\w{8}$/g.test(input);
+  },
+  (input, context) => {
+    return typeof input === "string" && /^us_sh_\w{8}$/g.test(input)
+      ? t.success(input)
+      : t.failure(input, context);
+  },
+  t.identity,
+);
+
 export const SheetCodec = t.intersection([
   t.strict({
-    id: t.string,
+    id: SheetIdCodec,
     config: SheetConfigCodec,
     createdAt: t.string,
     name: t.string,
@@ -149,6 +162,7 @@ export const SheetCodec = t.intersection([
 
 export type Permission = t.TypeOf<typeof PermissionCodec>;
 export type Sheet = Readonly<t.TypeOf<typeof SheetCodec>>;
+export type SheetId = Readonly<t.TypeOf<typeof SheetIdCodec>>;
 export type Sheets = ReadonlyArray<Sheet>;
 export type CreateSheetInput = Omit<Sheet, "id">;
 export type UpdateSheetInput = Partial<Sheet>;
@@ -193,7 +207,7 @@ export function createSheet(
  * @since 0.1.0
  */
 export function deleteSheet(
-  sheetId: string,
+  sheetId: SheetId,
 ): RT.ReaderTask<ApiReader, DecoderErrors | HttpError | Successful<{ success: boolean }>> {
   return pipe(
     RTE.ask<ApiReader>(),
@@ -223,7 +237,7 @@ export function deleteSheet(
  * @since 0.1.0
  */
 export function getSheet(
-  sheetId: string,
+  sheetId: SheetId,
 ): RT.ReaderTask<ApiReader, DecoderErrors | HttpError | Successful<Sheet>> {
   return pipe(
     RTE.ask<ApiReader>(),

--- a/packages/ffx-api/src/lib/sheets.mts
+++ b/packages/ffx-api/src/lib/sheets.mts
@@ -21,17 +21,17 @@ import {
 // ==================
 
 export const codecCustomAction = t.intersection([
-  t.strict({
+  t.type({
     label: t.string,
   }),
   t.partial({
     confirm: t.boolean,
     description: t.string,
     icon: t.string,
-    inputForm: t.strict({
+    inputForm: t.type({
       fields: t.array(
         t.intersection([
-          t.strict({
+          t.type({
             key: t.string,
             label: t.string,
             type: t.union([
@@ -43,9 +43,9 @@ export const codecCustomAction = t.intersection([
             ]),
           }),
           t.partial({
-            config: t.strict({
+            config: t.type({
               options: t.intersection([
-                t.strict({
+                t.type({
                   value: t.union([t.boolean, t.number, t.string]),
                 }),
                 t.partial({
@@ -58,7 +58,7 @@ export const codecCustomAction = t.intersection([
               ]),
             }),
             constraints: t.array(
-              t.strict({
+              t.type({
                 type: t.literal("required"),
               }),
             ),
@@ -79,13 +79,13 @@ export const codecCustomAction = t.intersection([
 ]);
 
 const codecField = t.intersection([
-  t.strict({
+  t.type({
     key: t.string,
     type: t.string,
   }),
   t.partial({
     constraints: t.array(
-      t.strict({
+      t.type({
         type: t.literal("required"),
       }),
     ),
@@ -106,7 +106,7 @@ const codecPermission = t.union([
 ]);
 
 const codecSheetConfig = t.intersection([
-  t.strict({
+  t.type({
     fields: t.array(codecField),
     name: t.string,
   }),
@@ -139,7 +139,7 @@ export const codecSheetId = new t.Type<SheetId, SheetId, unknown>(
 );
 
 export const codecSheet = t.intersection([
-  t.strict({
+  t.type({
     id: codecSheetId,
     config: codecSheetConfig,
     createdAt: t.string,
@@ -149,7 +149,7 @@ export const codecSheet = t.intersection([
   }),
   t.partial({
     countRecords: t.intersection([
-      t.strict({
+      t.type({
         error: t.number,
         total: t.number,
         valid: t.number,
@@ -231,7 +231,7 @@ export function deleteSheet(
       );
     }),
     RTE.map((resp) => resp.data.data),
-    RTE.chain(decodeWith(t.strict({ success: t.boolean }))),
+    RTE.chain(decodeWith(t.type({ success: t.boolean }))),
     RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
   );
 }

--- a/packages/ffx-api/src/lib/sheets.mts
+++ b/packages/ffx-api/src/lib/sheets.mts
@@ -169,42 +169,10 @@ export const codecSheet = t.intersection([
 export type Permission = t.TypeOf<typeof codecPermission>;
 export type Sheet = Readonly<t.TypeOf<typeof codecSheet>>;
 export type Sheets = ReadonlyArray<Sheet>;
-export type CreateSheetInput = Omit<Sheet, "id">;
-export type UpdateSheetInput = Partial<Sheet>;
 
 // ==================
 //       Main
 // ==================
-
-/**
- * Create a `Sheet`.
- *
- * @since 0.1.0
- */
-export function createSheet(
-  input: CreateSheetInput,
-): RT.ReaderTask<ApiReader, DecoderErrors | HttpError | Successful<Sheet>> {
-  return pipe(
-    RTE.ask<ApiReader>(),
-    RTE.chain((r) => {
-      return RTE.fromTaskEither(
-        TE.tryCatch(
-          () => {
-            return axios.post(`${r.baseUrl}/sheets`, input, {
-              headers: {
-                "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
-              },
-            });
-          },
-          (reason: unknown) => reason as AxiosError,
-        ),
-      );
-    }),
-    RTE.map((resp) => resp.data.data),
-    RTE.chain(decodeWith(codecSheet)),
-    RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
-  );
-}
 
 /**
  * Delete a `Sheet`.
@@ -293,36 +261,6 @@ export function listSheets(): RT.ReaderTask<
     }),
     RTE.map((resp) => resp.data.data),
     RTE.chain(decodeWith(t.array(codecSheet))),
-    RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
-  );
-}
-
-/**
- * Update a `Sheet`.
- *
- * @since 0.1.0
- */
-export function updateSheet(
-  input: UpdateSheetInput,
-): RT.ReaderTask<ApiReader, DecoderErrors | HttpError | Successful<Sheet>> {
-  return pipe(
-    RTE.ask<ApiReader>(),
-    RTE.chain((r) => {
-      return RTE.fromTaskEither(
-        TE.tryCatch(
-          () => {
-            return axios.patch(`${r.baseUrl}/sheets/${input.id}`, input, {
-              headers: {
-                "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
-              },
-            });
-          },
-          (reason: unknown) => reason as AxiosError,
-        ),
-      );
-    }),
-    RTE.map((resp) => resp.data.data),
-    RTE.chain(decodeWith(codecSheet)),
     RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
   );
 }

--- a/packages/ffx-api/src/lib/sheets.mts
+++ b/packages/ffx-api/src/lib/sheets.mts
@@ -1,0 +1,290 @@
+import axios, { AxiosError } from "axios";
+import { identity, pipe } from "fp-ts/function";
+import * as RT from "fp-ts/ReaderTask";
+import * as RTE from "fp-ts/ReaderTaskEither";
+import * as TE from "fp-ts/TaskEither";
+import * as t from "io-ts";
+
+import {
+  ApiReader,
+  DecoderErrors,
+  HttpError,
+  Successful,
+  decodeWith,
+  mkHttpError,
+} from "./types.mjs";
+
+// ==================
+//   Runtime codecs
+// ==================
+
+export const CustomActionCodec = t.intersection([
+  t.type({
+    label: t.string,
+  }),
+  t.partial({
+    confirm: t.boolean,
+    description: t.string,
+    icon: t.string,
+    inputForm: t.type({
+      fields: t.array(
+        t.intersection([
+          t.type({
+            key: t.string,
+            label: t.string,
+            type: t.union([
+              t.literal("boolean"),
+              t.literal("enum"),
+              t.literal("number"),
+              t.literal("string"),
+              t.literal("textarea"),
+            ]),
+          }),
+          t.partial({
+            config: t.type({
+              color: t.string,
+              description: t.string,
+              icon: t.string,
+              label: t.string,
+              meta: t.UnknownRecord,
+              value: t.union([t.boolean, t.number, t.string]),
+            }),
+            constraints: t.array(
+              t.type({
+                type: t.literal("required"),
+              }),
+            ),
+            description: t.string,
+          }),
+        ]),
+      ),
+      type: t.literal("simple"),
+    }),
+    mode: t.union([t.literal("background"), t.literal("foreground")]),
+    operation: t.string,
+    primary: t.boolean,
+    requireAllValid: t.boolean,
+    requireSelection: t.boolean,
+    schedule: t.union([t.literal("daily"), t.literal("hourly"), t.literal("weekly")]),
+    tooltip: t.string,
+  }),
+]);
+
+const PermissionCodec = t.union([
+  t.literal("*"),
+  t.literal("add"),
+  t.literal("delete"),
+  t.literal("edit"),
+  t.literal("import"),
+]);
+
+const SheetConfigCodec = t.intersection([
+  t.type({
+    fields: t.array(t.string),
+    name: t.string,
+  }),
+  t.partial({
+    access: t.array(PermissionCodec),
+    actions: t.array(CustomActionCodec),
+    allowAdditionalFields: t.boolean,
+    metadata: t.UnknownRecord,
+    readonly: t.boolean,
+    slug: t.string,
+  }),
+]);
+
+export const SheetCodec = t.intersection([
+  t.type({
+    id: t.string,
+    config: SheetConfigCodec,
+    createdAt: t.string,
+    fields: t.array(t.string),
+    name: t.string,
+    updatedAt: t.string,
+    workbookId: t.string,
+  }),
+  t.partial({
+    access: t.array(PermissionCodec),
+    actions: t.array(CustomActionCodec),
+    allowAdditionalFields: t.boolean,
+    countRecords: t.intersection([
+      t.type({
+        error: t.number,
+        total: t.number,
+        valid: t.number,
+      }),
+      t.partial({
+        errorsByField: t.UnknownRecord,
+      }),
+    ]),
+    description: t.string,
+    metadata: t.UnknownRecord,
+    namespace: t.string,
+    readonly: t.boolean,
+    slug: t.string,
+  }),
+]);
+
+// ==================
+//       Types
+// ==================
+
+export type Sheet = Readonly<t.TypeOf<typeof SheetCodec>>;
+export type Sheets = ReadonlyArray<Sheet>;
+export type CreateSheetInput = Omit<Sheet, "id">;
+export type UpdateSheetInput = Partial<Sheet>;
+
+// ==================
+//       Main
+// ==================
+
+/**
+ * Create a `Sheet`.
+ *
+ * @since 0.1.0
+ */
+export function createSheet(
+  input: CreateSheetInput,
+): RT.ReaderTask<ApiReader, DecoderErrors | HttpError | Successful<Sheet>> {
+  return pipe(
+    RTE.ask<ApiReader>(),
+    RTE.chain((r) => {
+      return RTE.fromTaskEither(
+        TE.tryCatch(
+          () => {
+            return axios.post(`${r.baseUrl}/sheets`, input, {
+              headers: {
+                "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
+              },
+            });
+          },
+          (reason: unknown) => reason as AxiosError,
+        ),
+      );
+    }),
+    RTE.map((resp) => resp.data.data),
+    RTE.chain(decodeWith(SheetCodec)),
+    RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
+  );
+}
+
+/**
+ * Delete a `Sheet`.
+ *
+ * @since 0.1.0
+ */
+export function deleteSheet(
+  sheetId: string,
+): RT.ReaderTask<ApiReader, DecoderErrors | HttpError | Successful<{ success: boolean }>> {
+  return pipe(
+    RTE.ask<ApiReader>(),
+    RTE.chain((r) => {
+      return RTE.fromTaskEither(
+        TE.tryCatch(
+          () => {
+            return axios.delete(`${r.baseUrl}/sheets/${sheetId}`, {
+              headers: {
+                "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
+              },
+            });
+          },
+          (reason: unknown) => reason as AxiosError,
+        ),
+      );
+    }),
+    RTE.map((resp) => resp.data.data),
+    RTE.chain(decodeWith(t.type({ success: t.boolean }))),
+    RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
+  );
+}
+
+/**
+ * Get a `Sheet`.
+ *
+ * @since 0.1.0
+ */
+export function getSheet(
+  sheetId: string,
+): RT.ReaderTask<ApiReader, DecoderErrors | HttpError | Successful<Sheet>> {
+  return pipe(
+    RTE.ask<ApiReader>(),
+    RTE.chain((r) => {
+      return RTE.fromTaskEither(
+        TE.tryCatch(
+          () => {
+            return axios.get(`${r.baseUrl}/sheets/${sheetId}`, {
+              headers: {
+                "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
+              },
+            });
+          },
+          (reason: unknown) => reason as AxiosError,
+        ),
+      );
+    }),
+    RTE.map((resp) => resp.data.data),
+    RTE.chain(decodeWith(SheetCodec)),
+    RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
+  );
+}
+
+/**
+ * Get a list of `Sheet`s.
+ *
+ * @since 0.1.0
+ */
+export function listSheets(): RT.ReaderTask<
+  ApiReader,
+  DecoderErrors | HttpError | Successful<Sheets>
+> {
+  return pipe(
+    RTE.ask<ApiReader>(),
+    RTE.chain((r) => {
+      return RTE.fromTaskEither(
+        TE.tryCatch(
+          () => {
+            return axios.get(`${r.baseUrl}/sheets`, {
+              headers: {
+                "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
+              },
+            });
+          },
+          (reason: unknown) => reason as AxiosError,
+        ),
+      );
+    }),
+    RTE.map((resp) => resp.data.data),
+    RTE.chain(decodeWith(t.array(SheetCodec))),
+    RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
+  );
+}
+
+/**
+ * Update a `Sheet`.
+ *
+ * @since 0.1.0
+ */
+export function updateSheet(
+  input: UpdateSheetInput,
+): RT.ReaderTask<ApiReader, DecoderErrors | HttpError | Successful<Sheet>> {
+  return pipe(
+    RTE.ask<ApiReader>(),
+    RTE.chain((r) => {
+      return RTE.fromTaskEither(
+        TE.tryCatch(
+          () => {
+            return axios.patch(`${r.baseUrl}/sheets/${input.id}`, input, {
+              headers: {
+                "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
+              },
+            });
+          },
+          (reason: unknown) => reason as AxiosError,
+        ),
+      );
+    }),
+    RTE.map((resp) => resp.data.data),
+    RTE.chain(decodeWith(SheetCodec)),
+    RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
+  );
+}

--- a/packages/ffx-api/src/lib/sheets.mts
+++ b/packages/ffx-api/src/lib/sheets.mts
@@ -42,12 +42,18 @@ export const CustomActionCodec = t.intersection([
           }),
           t.partial({
             config: t.type({
-              color: t.string,
-              description: t.string,
-              icon: t.string,
-              label: t.string,
-              meta: t.UnknownRecord,
-              value: t.union([t.boolean, t.number, t.string]),
+              options: t.intersection([
+                t.type({
+                  value: t.union([t.boolean, t.number, t.string]),
+                }),
+                t.partial({
+                  color: t.string,
+                  description: t.string,
+                  icon: t.string,
+                  label: t.string,
+                  meta: t.UnknownRecord,
+                }),
+              ]),
             }),
             constraints: t.array(
               t.type({
@@ -70,6 +76,25 @@ export const CustomActionCodec = t.intersection([
   }),
 ]);
 
+const FieldCodec = t.intersection([
+  t.type({
+    key: t.string,
+    type: t.string,
+  }),
+  t.partial({
+    constraints: t.array(
+      t.type({
+        type: t.literal("required"),
+      }),
+    ),
+    description: t.string,
+    label: t.string,
+    metadata: t.UnknownRecord,
+    readonly: t.boolean,
+    treatments: t.array(t.string),
+  }),
+]);
+
 const PermissionCodec = t.union([
   t.literal("*"),
   t.literal("add"),
@@ -80,13 +105,14 @@ const PermissionCodec = t.union([
 
 const SheetConfigCodec = t.intersection([
   t.type({
-    fields: t.array(t.string),
+    fields: t.array(FieldCodec),
     name: t.string,
   }),
   t.partial({
     access: t.array(PermissionCodec),
     actions: t.array(CustomActionCodec),
     allowAdditionalFields: t.boolean,
+    description: t.string,
     metadata: t.UnknownRecord,
     readonly: t.boolean,
     slug: t.string,
@@ -98,15 +124,11 @@ export const SheetCodec = t.intersection([
     id: t.string,
     config: SheetConfigCodec,
     createdAt: t.string,
-    fields: t.array(t.string),
     name: t.string,
     updatedAt: t.string,
     workbookId: t.string,
   }),
   t.partial({
-    access: t.array(PermissionCodec),
-    actions: t.array(CustomActionCodec),
-    allowAdditionalFields: t.boolean,
     countRecords: t.intersection([
       t.type({
         error: t.number,
@@ -117,11 +139,7 @@ export const SheetCodec = t.intersection([
         errorsByField: t.UnknownRecord,
       }),
     ]),
-    description: t.string,
-    metadata: t.UnknownRecord,
     namespace: t.string,
-    readonly: t.boolean,
-    slug: t.string,
   }),
 ]);
 
@@ -129,6 +147,7 @@ export const SheetCodec = t.intersection([
 //       Types
 // ==================
 
+export type Permission = t.TypeOf<typeof PermissionCodec>;
 export type Sheet = Readonly<t.TypeOf<typeof SheetCodec>>;
 export type Sheets = ReadonlyArray<Sheet>;
 export type CreateSheetInput = Omit<Sheet, "id">;

--- a/packages/ffx-api/src/lib/types.mts
+++ b/packages/ffx-api/src/lib/types.mts
@@ -5,6 +5,8 @@ import * as RTE from "fp-ts/ReaderTaskEither";
 import * as t from "io-ts";
 import { formatValidationErrors } from "io-ts-reporters";
 
+import { EnvironmentId } from "./environments.mjs";
+
 // ==================
 //   Runtime codecs
 // ==================
@@ -23,7 +25,7 @@ const HttpMethodCodec = t.union([
 
 export interface ApiReader {
   readonly baseUrl: string;
-  readonly environmentId: string;
+  readonly environmentId: EnvironmentId;
   readonly pkgJson: Readonly<{
     name: string;
     version: string;

--- a/packages/ffx-api/src/lib/workbooks.mts
+++ b/packages/ffx-api/src/lib/workbooks.mts
@@ -1,0 +1,202 @@
+import axios, { AxiosError } from "axios";
+import { identity, pipe } from "fp-ts/function";
+import * as RT from "fp-ts/ReaderTask";
+import * as RTE from "fp-ts/ReaderTaskEither";
+import * as TE from "fp-ts/TaskEither";
+import * as t from "io-ts";
+
+import { CustomActionCodec, SheetCodec } from "./sheets.mjs";
+import {
+  ApiReader,
+  DecoderErrors,
+  HttpError,
+  Successful,
+  decodeWith,
+  mkHttpError,
+} from "./types.mjs";
+
+// ==================
+//   Runtime codecs
+// ==================
+
+export const WorkbookCodec = t.intersection([
+  t.type({
+    id: t.string,
+    createdAt: t.string,
+    environmentId: t.string,
+    name: t.string,
+    spaceId: t.string,
+    updatedAt: t.string,
+  }),
+  t.partial({
+    actions: t.array(CustomActionCodec),
+    labels: t.array(t.string),
+    metadata: t.string,
+    namespace: t.string,
+    sheets: t.array(SheetCodec),
+  }),
+]);
+
+// ==================
+//       Types
+// ==================
+
+export type Workbook = Readonly<t.TypeOf<typeof WorkbookCodec>>;
+export type Workbooks = ReadonlyArray<Workbook>;
+export type CreateWorkbookInput = Omit<Workbook, "id">;
+export type UpdateWorkbookInput = Partial<Workbook>;
+
+// ==================
+//       Main
+// ==================
+
+/**
+ * Create a `Workbook`.
+ *
+ * @since 0.1.0
+ */
+export function createWorkbook(
+  input: CreateWorkbookInput,
+): RT.ReaderTask<ApiReader, DecoderErrors | HttpError | Successful<Workbook>> {
+  return pipe(
+    RTE.ask<ApiReader>(),
+    RTE.chain((r) => {
+      return RTE.fromTaskEither(
+        TE.tryCatch(
+          () => {
+            return axios.post(`${r.baseUrl}/workbooks`, input, {
+              headers: {
+                "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
+              },
+            });
+          },
+          (reason: unknown) => reason as AxiosError,
+        ),
+      );
+    }),
+    RTE.map((resp) => resp.data.data),
+    RTE.chain(decodeWith(WorkbookCodec)),
+    RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
+  );
+}
+
+/**
+ * Delete a `Workbook`.
+ *
+ * @since 0.1.0
+ */
+export function deleteWorkbook(
+  workbookId: string,
+): RT.ReaderTask<ApiReader, DecoderErrors | HttpError | Successful<{ success: boolean }>> {
+  return pipe(
+    RTE.ask<ApiReader>(),
+    RTE.chain((r) => {
+      return RTE.fromTaskEither(
+        TE.tryCatch(
+          () => {
+            return axios.delete(`${r.baseUrl}/workbooks/${workbookId}`, {
+              headers: {
+                "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
+              },
+            });
+          },
+          (reason: unknown) => reason as AxiosError,
+        ),
+      );
+    }),
+    RTE.map((resp) => resp.data.data),
+    RTE.chain(decodeWith(t.type({ success: t.boolean }))),
+    RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
+  );
+}
+
+/**
+ * Get a `Workbook`.
+ *
+ * @since 0.1.0
+ */
+export function getWorkbook(
+  workbookId: string,
+): RT.ReaderTask<ApiReader, DecoderErrors | HttpError | Successful<Workbook>> {
+  return pipe(
+    RTE.ask<ApiReader>(),
+    RTE.chain((r) => {
+      return RTE.fromTaskEither(
+        TE.tryCatch(
+          () => {
+            return axios.get(`${r.baseUrl}/workbooks/${workbookId}`, {
+              headers: {
+                "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
+              },
+            });
+          },
+          (reason: unknown) => reason as AxiosError,
+        ),
+      );
+    }),
+    RTE.map((resp) => resp.data.data),
+    RTE.chain(decodeWith(WorkbookCodec)),
+    RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
+  );
+}
+
+/**
+ * Get a list of `Workbook`s.
+ *
+ * @since 0.1.0
+ */
+export function listWorkbooks(): RT.ReaderTask<
+  ApiReader,
+  DecoderErrors | HttpError | Successful<Workbooks>
+> {
+  return pipe(
+    RTE.ask<ApiReader>(),
+    RTE.chain((r) => {
+      return RTE.fromTaskEither(
+        TE.tryCatch(
+          () => {
+            return axios.get(`${r.baseUrl}/workbooks`, {
+              headers: {
+                "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
+              },
+            });
+          },
+          (reason: unknown) => reason as AxiosError,
+        ),
+      );
+    }),
+    RTE.map((resp) => resp.data.data),
+    RTE.chain(decodeWith(t.array(WorkbookCodec))),
+    RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
+  );
+}
+
+/**
+ * Update a `Workbook`.
+ *
+ * @since 0.1.0
+ */
+export function updateWorkbook(
+  input: UpdateWorkbookInput,
+): RT.ReaderTask<ApiReader, DecoderErrors | HttpError | Successful<Workbook>> {
+  return pipe(
+    RTE.ask<ApiReader>(),
+    RTE.chain((r) => {
+      return RTE.fromTaskEither(
+        TE.tryCatch(
+          () => {
+            return axios.patch(`${r.baseUrl}/workbooks/${input.id}`, input, {
+              headers: {
+                "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
+              },
+            });
+          },
+          (reason: unknown) => reason as AxiosError,
+        ),
+      );
+    }),
+    RTE.map((resp) => resp.data.data),
+    RTE.chain(decodeWith(WorkbookCodec)),
+    RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
+  );
+}

--- a/packages/ffx-api/src/lib/workbooks.mts
+++ b/packages/ffx-api/src/lib/workbooks.mts
@@ -41,7 +41,7 @@ export const codecWorkbookId = new t.Type<WorkbookId, WorkbookId, unknown>(
 );
 
 export const codecWorkbook = t.intersection([
-  t.strict({
+  t.type({
     id: codecWorkbookId,
     createdAt: t.string,
     environmentId: codecEnvironmentId,
@@ -126,7 +126,7 @@ export function deleteWorkbook(
       );
     }),
     RTE.map((resp) => resp.data.data),
-    RTE.chain(decodeWith(t.strict({ success: t.boolean }))),
+    RTE.chain(decodeWith(t.type({ success: t.boolean }))),
     RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
   );
 }

--- a/packages/ffx-api/src/lib/workbooks.mts
+++ b/packages/ffx-api/src/lib/workbooks.mts
@@ -64,8 +64,8 @@ export const codecWorkbook = t.intersection([
 
 export type Workbook = Readonly<t.TypeOf<typeof codecWorkbook>>;
 export type Workbooks = ReadonlyArray<Workbook>;
-export type CreateWorkbookInput = Omit<Workbook, "id">;
-export type UpdateWorkbookInput = Partial<Workbook>;
+export type CreateWorkbookInput = Omit<Workbook, "id" | "createdAt" | "updatedAt">;
+export type UpdateWorkbookInput = Partial<Omit<Workbook, "id" | "createdAt" | "updatedAt">>;
 
 // ==================
 //       Main
@@ -198,6 +198,7 @@ export function listWorkbooks(): RT.ReaderTask<
  * @since 0.1.0
  */
 export function updateWorkbook(
+  workbookId: WorkbookId,
   input: UpdateWorkbookInput,
 ): RT.ReaderTask<ApiReader, DecoderErrors | HttpError | Successful<Workbook>> {
   return pipe(
@@ -206,7 +207,7 @@ export function updateWorkbook(
       return RTE.fromTaskEither(
         TE.tryCatch(
           () => {
-            return axios.patch(`${r.baseUrl}/workbooks/${input.id}`, input, {
+            return axios.patch(`${r.baseUrl}/workbooks/${workbookId}`, input, {
               headers: {
                 "User-Agent": `${r.pkgJson.name}/v${r.pkgJson.version}`,
               },

--- a/packages/ffx-api/src/lib/workbooks.mts
+++ b/packages/ffx-api/src/lib/workbooks.mts
@@ -20,7 +20,7 @@ import {
 // ==================
 
 export const WorkbookCodec = t.intersection([
-  t.type({
+  t.strict({
     id: t.string,
     createdAt: t.string,
     environmentId: t.string,
@@ -105,7 +105,7 @@ export function deleteWorkbook(
       );
     }),
     RTE.map((resp) => resp.data.data),
-    RTE.chain(decodeWith(t.type({ success: t.boolean }))),
+    RTE.chain(decodeWith(t.strict({ success: t.boolean }))),
     RTE.matchW((axiosError) => mkHttpError(axiosError), identity),
   );
 }

--- a/packages/ffx-api/src/lib/workbooks.mts
+++ b/packages/ffx-api/src/lib/workbooks.mts
@@ -31,7 +31,7 @@ export const WorkbookCodec = t.intersection([
   t.partial({
     actions: t.array(CustomActionCodec),
     labels: t.array(t.string),
-    metadata: t.string,
+    metadata: t.UnknownRecord,
     namespace: t.string,
     sheets: t.array(SheetCodec),
   }),

--- a/packages/ffx-api/test/agents.spec.mts
+++ b/packages/ffx-api/test/agents.spec.mts
@@ -89,7 +89,7 @@ describe("agents", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.agents.create(_mkMockAgent()());
+      const resp = await client.agents.create(mockAgent);
 
       match(resp)
         .with({ _tag: "decoder_errors" }, ({ reasons }) =>

--- a/packages/ffx-api/test/agents.spec.mts
+++ b/packages/ffx-api/test/agents.spec.mts
@@ -8,6 +8,7 @@ import { match } from "ts-pattern";
 
 import mkApiClient from "../src/index.mjs";
 import { Agent, AgentCodec, AgentIdCodec, Agents, CreateAgentInput } from "../src/lib/agents.mjs";
+import { EnvironmentId } from "../src/lib/environments.mjs";
 
 function randomId(): IO.IO<string> {
   return IO.of(Math.random().toString(16).slice(2, 10));
@@ -39,7 +40,7 @@ describe("agents", () => {
 
   describe("[Mocks]", () => {
     const secret: string = "secret";
-    const environmentId: string = "environmentId";
+    const environmentId: EnvironmentId = "environmentId";
     const client = mkApiClient(secret, environmentId);
     const baseUrl: string = "https://platform.flatfile.com/api/v1";
 

--- a/packages/ffx-api/test/documents.spec.mts
+++ b/packages/ffx-api/test/documents.spec.mts
@@ -8,7 +8,7 @@ import { match } from "ts-pattern";
 
 import mkApiClient from "../src/index.mjs";
 import { Document, DocumentCodec, DocumentIdCodec, SpaceIdCodec } from "../src/lib/documents.mjs";
-import { EnvironmentIdCodec } from "../src/lib/environments.mjs";
+import { EnvironmentId, EnvironmentIdCodec } from "../src/lib/environments.mjs";
 
 function randomId(): IO.IO<string> {
   return IO.of(Math.random().toString(16).slice(2, 10));
@@ -47,7 +47,7 @@ describe("documents", () => {
 
   describe("[Mocks]", () => {
     const secret: string = "secret";
-    const environmentId: string = "environmentId";
+    const environmentId: EnvironmentId = "environmentId";
     const client = mkApiClient(secret, environmentId);
     const baseUrl: string = "https://platform.flatfile.com/api/v1";
 

--- a/packages/ffx-api/test/documents.spec.mts
+++ b/packages/ffx-api/test/documents.spec.mts
@@ -83,9 +83,8 @@ describe("documents", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.documents.create({
+      const resp = await client.documents.create(mockDocument.spaceId, {
         body: mockDocument.body,
-        spaceId: mockDocument.spaceId,
         title: mockDocument.title,
       });
 
@@ -119,16 +118,15 @@ describe("documents", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.documents.create({
+      const resp = await client.documents.create(mockDocument.spaceId, {
         body: mockDocument.body,
-        spaceId: mockDocument.spaceId,
         title: mockDocument.title,
       });
 
       match(resp)
         .with({ _tag: "decoder_errors" }, ({ reasons }) =>
           expect(reasons).toStrictEqual([
-            `Expecting DocumentId at id but instead got: "bogus_document_id"`,
+            `Expecting DocumentId at 0.id but instead got: "bogus_document_id"`,
           ]),
         )
         .otherwise(() => assert.fail(`Received unexpected:\n${JSON.stringify(resp, null, 2)}`));
@@ -151,9 +149,8 @@ describe("documents", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.documents.create({
+      const resp = await client.documents.create(mockDocument.spaceId, {
         body: mockDocument.body,
-        spaceId: mockDocument.spaceId,
         title: mockDocument.title,
       });
 
@@ -192,10 +189,7 @@ describe("documents", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.documents.delete({
-        id: mockDocument.id,
-        spaceId: mockDocument.spaceId,
-      });
+      const resp = await client.documents.delete(mockDocument.id, mockDocument.spaceId);
 
       match(resp)
         .with({ _tag: "http_error" }, (httpError) => expect(httpError.statusCode).toEqual(400))
@@ -229,10 +223,7 @@ describe("documents", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.documents.delete({
-        id: mockDocument.id,
-        spaceId: mockDocument.spaceId,
-      });
+      const resp = await client.documents.delete(mockDocument.id, mockDocument.spaceId);
 
       match(resp)
         .with({ _tag: "decoder_errors" }, ({ reasons }) =>
@@ -268,10 +259,7 @@ describe("documents", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.documents.delete({
-        id: mockDocument.id,
-        spaceId: mockDocument.spaceId,
-      });
+      const resp = await client.documents.delete(mockDocument.id, mockDocument.spaceId);
 
       match(resp)
         .with({ _tag: "successful" }, ({ data }) => expect(data).toStrictEqual({ success: true }))
@@ -308,10 +296,7 @@ describe("documents", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.documents.get({
-        id: mockDocument.id,
-        spaceId: mockDocument.spaceId,
-      });
+      const resp = await client.documents.get(mockDocument.id, mockDocument.spaceId);
 
       match(resp)
         .with({ _tag: "http_error" }, (httpError) => expect(httpError.statusCode).toEqual(400))
@@ -346,14 +331,11 @@ describe("documents", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.documents.get({
-        id: mockDocument.id,
-        spaceId: mockDocument.spaceId,
-      });
+      const resp = await client.documents.get(mockDocument.id, mockDocument.spaceId);
 
       match(resp)
         .with({ _tag: "decoder_errors" }, ({ reasons }) =>
-          expect(reasons).toStrictEqual([`Expecting SpaceId at spaceId but instead got: null`]),
+          expect(reasons).toStrictEqual([`Expecting SpaceId at 0.spaceId but instead got: null`]),
         )
         .otherwise(() => assert.fail(`Received unexpected:\n${JSON.stringify(resp, null, 2)}`));
 
@@ -383,10 +365,7 @@ describe("documents", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.documents.get({
-        id: mockDocument.id,
-        spaceId: mockDocument.spaceId,
-      });
+      const resp = await client.documents.get(mockDocument.id, mockDocument.spaceId);
 
       match(resp)
         .with({ _tag: "successful" }, ({ data }) => expect(data).toStrictEqual(mockDocument))
@@ -458,7 +437,7 @@ describe("documents", () => {
 
       match(resp)
         .with({ _tag: "decoder_errors" }, ({ reasons }) =>
-          expect(reasons).toStrictEqual([`Expecting SpaceId at 0.spaceId but instead got: null`]),
+          expect(reasons).toStrictEqual([`Expecting SpaceId at 0.0.spaceId but instead got: null`]),
         )
         .otherwise(() => assert.fail(`Received unexpected:\n${JSON.stringify(resp, null, 2)}`));
 
@@ -522,7 +501,11 @@ describe("documents", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.documents.update(mockDocument);
+      const resp = await client.documents.update(mockDocument.id, mockDocument.spaceId, {
+        body: mockDocument.body,
+        title: mockDocument.title,
+        treatments: mockDocument.treatments,
+      });
 
       match(resp)
         .with({ _tag: "http_error" }, (httpError) => expect(httpError.statusCode).toEqual(400))
@@ -557,11 +540,15 @@ describe("documents", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.documents.update(mockDocument);
+      const resp = await client.documents.update(mockDocument.id, mockDocument.spaceId, {
+        body: mockDocument.body,
+        title: mockDocument.title,
+        treatments: mockDocument.treatments,
+      });
 
       match(resp)
         .with({ _tag: "decoder_errors" }, ({ reasons }) =>
-          expect(reasons).toStrictEqual([`Expecting SpaceId at spaceId but instead got: null`]),
+          expect(reasons).toStrictEqual([`Expecting SpaceId at 0.spaceId but instead got: null`]),
         )
         .otherwise(() => assert.fail(`Received unexpected:\n${JSON.stringify(resp, null, 2)}`));
 
@@ -591,7 +578,11 @@ describe("documents", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.documents.update(mockDocument);
+      const resp = await client.documents.update(mockDocument.id, mockDocument.spaceId, {
+        body: mockDocument.body,
+        title: mockDocument.title,
+        treatments: mockDocument.treatments,
+      });
 
       match(resp)
         .with({ _tag: "successful" }, ({ data }) => expect(data).toStrictEqual(mockDocument))

--- a/packages/ffx-api/test/environments.spec.mts
+++ b/packages/ffx-api/test/environments.spec.mts
@@ -321,7 +321,7 @@ describe("environments", () => {
             ctx.json({
               data: {
                 ...mockEnvironment,
-                id: null,
+                accountId: null,
               },
             }),
           );
@@ -336,7 +336,9 @@ describe("environments", () => {
 
       match(resp)
         .with({ _tag: "decoder_errors" }, ({ reasons }) =>
-          expect(reasons).toStrictEqual([`Expecting EnvironmentId at 0.id but instead got: null`]),
+          expect(reasons).toStrictEqual([
+            `Expecting AccountId at 0.accountId but instead got: null`,
+          ]),
         )
         .otherwise(() => assert.fail(`Received unexpected:\n${JSON.stringify(resp, null, 2)}`));
 

--- a/packages/ffx-api/test/environments.spec.mts
+++ b/packages/ffx-api/test/environments.spec.mts
@@ -8,11 +8,13 @@ import { match } from "ts-pattern";
 
 import mkApiClient from "../src/index.mjs";
 import {
-  AccountIdCodec,
   Environment,
-  EnvironmentCodec,
   EnvironmentId,
-  EnvironmentIdCodec,
+  codecAccountId,
+  codecEnvironment,
+  codecEnvironmentId,
+  isoAccountId,
+  isoEnvironmentId,
 } from "../src/lib/environments.mjs";
 
 function randomId(): IO.IO<string> {
@@ -21,8 +23,8 @@ function randomId(): IO.IO<string> {
 
 function _mkMockEnvironment(): IO.IO<Environment> {
   return IO.of({
-    id: EnvironmentIdCodec.encode(`us_env_${randomId()()}`),
-    accountId: AccountIdCodec.encode(`us_acc_${randomId()()}`),
+    id: isoEnvironmentId.wrap(`us_env_${randomId()()}`),
+    accountId: isoAccountId.wrap(`us_acc_${randomId()()}`),
     features: {},
     guestAuthentication: [faker.helpers.arrayElement(["magic_link", "shared_link"])],
     isProd: faker.helpers.arrayElement([false, true]),
@@ -34,27 +36,27 @@ function _mkMockEnvironment(): IO.IO<Environment> {
 describe("environments", () => {
   describe("[Codecs]", () => {
     it("Environment", () => {
-      const decoded = pipe(_mkMockEnvironment()(), EnvironmentCodec.decode);
+      const decoded = pipe(_mkMockEnvironment()(), codecEnvironment.decode);
 
       expect(E.isRight(decoded)).toBe(true);
     });
 
     it("EnvironmentId", () => {
-      const encoded = EnvironmentIdCodec.encode(`us_env_${randomId()()}`);
+      const encoded = isoEnvironmentId.wrap(`us_env_${randomId()()}`);
 
-      expect(EnvironmentIdCodec.is(encoded)).toBe(true);
+      expect(codecEnvironmentId.is(encoded)).toBe(true);
     });
 
     it("AccountId", () => {
-      const encoded = AccountIdCodec.encode(`us_acc_${randomId()()}`);
+      const encoded = isoAccountId.wrap(`us_acc_${randomId()()}`);
 
-      expect(AccountIdCodec.is(encoded)).toBe(true);
+      expect(codecAccountId.is(encoded)).toBe(true);
     });
   });
 
   describe("[Mocks]", () => {
     const secret: string = "secret";
-    const environmentId: EnvironmentId = "environmentId";
+    const environmentId: EnvironmentId = isoEnvironmentId.wrap("environmentId");
     const client = mkApiClient(secret, environmentId);
     const baseUrl: string = "https://platform.flatfile.com/api/v1";
 

--- a/packages/ffx-api/test/environments.spec.mts
+++ b/packages/ffx-api/test/environments.spec.mts
@@ -501,7 +501,14 @@ describe("environments", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.environments.update(mockEnvironment);
+      const resp = await client.environments.update(mockEnvironment.id, {
+        guestAuthentication: mockEnvironment.guestAuthentication,
+        isProd: mockEnvironment.isProd,
+        metadata: mockEnvironment.metadata,
+        name: mockEnvironment.name,
+        namespaces: mockEnvironment.namespaces,
+        translationsPath: mockEnvironment.translationsPath,
+      });
 
       match(resp)
         .with({ _tag: "http_error" }, (httpError) => expect(httpError.statusCode).toEqual(400))
@@ -533,7 +540,14 @@ describe("environments", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.environments.update(mockEnvironment);
+      const resp = await client.environments.update(mockEnvironment.id, {
+        guestAuthentication: mockEnvironment.guestAuthentication,
+        isProd: mockEnvironment.isProd,
+        metadata: mockEnvironment.metadata,
+        name: mockEnvironment.name,
+        namespaces: mockEnvironment.namespaces,
+        translationsPath: mockEnvironment.translationsPath,
+      });
 
       match(resp)
         .with({ _tag: "decoder_errors" }, ({ reasons }) =>
@@ -564,7 +578,14 @@ describe("environments", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.environments.update(mockEnvironment);
+      const resp = await client.environments.update(mockEnvironment.id, {
+        guestAuthentication: mockEnvironment.guestAuthentication,
+        isProd: mockEnvironment.isProd,
+        metadata: mockEnvironment.metadata,
+        name: mockEnvironment.name,
+        namespaces: mockEnvironment.namespaces,
+        translationsPath: mockEnvironment.translationsPath,
+      });
 
       match(resp)
         .with({ _tag: "successful" }, ({ data }) => expect(data).toStrictEqual(mockEnvironment))

--- a/packages/ffx-api/test/environments.spec.mts
+++ b/packages/ffx-api/test/environments.spec.mts
@@ -15,8 +15,8 @@ function randomId(): IO.IO<string> {
 
 function _mkMockEnvironment(): IO.IO<Environment> {
   return IO.of({
-    id: `us_env${randomId()()}`,
-    accountId: `us_act${randomId()()}`,
+    id: `us_env_${randomId()()}`,
+    accountId: `us_act_${randomId()()}`,
     features: {},
     guestAuthentication: [faker.helpers.arrayElement(["magic_link", "shared_link"])],
     isProd: faker.helpers.arrayElement([false, true]),

--- a/packages/ffx-api/test/environments.spec.mts
+++ b/packages/ffx-api/test/environments.spec.mts
@@ -11,6 +11,7 @@ import {
   AccountIdCodec,
   Environment,
   EnvironmentCodec,
+  EnvironmentId,
   EnvironmentIdCodec,
 } from "../src/lib/environments.mjs";
 
@@ -53,7 +54,7 @@ describe("environments", () => {
 
   describe("[Mocks]", () => {
     const secret: string = "secret";
-    const environmentId: string = "environmentId";
+    const environmentId: EnvironmentId = "environmentId";
     const client = mkApiClient(secret, environmentId);
     const baseUrl: string = "https://platform.flatfile.com/api/v1";
 

--- a/packages/ffx-api/test/sheets.spec.mts
+++ b/packages/ffx-api/test/sheets.spec.mts
@@ -7,6 +7,7 @@ import { setupServer } from "msw/node";
 import { match } from "ts-pattern";
 
 import mkApiClient from "../src/index.mjs";
+import { EnvironmentId } from "../src/lib/environments.mjs";
 import { CreateSheetInput, Sheet, Sheets, SheetCodec, SheetIdCodec } from "../src/lib/sheets.mjs";
 
 function randomId(): IO.IO<string> {
@@ -115,7 +116,7 @@ describe("sheets", () => {
 
   describe("[Mocks]", () => {
     const secret: string = "secret";
-    const environmentId: string = "environmentId";
+    const environmentId: EnvironmentId = "environmentId";
     const client = mkApiClient(secret, environmentId);
     const baseUrl: string = "https://platform.flatfile.com/api/v1";
 

--- a/packages/ffx-api/test/sheets.spec.mts
+++ b/packages/ffx-api/test/sheets.spec.mts
@@ -1,0 +1,206 @@
+import { faker } from "@faker-js/faker";
+import * as E from "fp-ts/Either";
+import { pipe } from "fp-ts/function";
+import * as IO from "fp-ts/IO";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
+import { match } from "ts-pattern";
+
+import mkApiClient from "../src/index.mjs";
+import { CreateSheetInput, Sheet, SheetCodec } from "../src/lib/sheets.mjs";
+
+function randomId(): IO.IO<string> {
+  return IO.of(Math.random().toString(16).slice(2, 10));
+}
+
+function _mkMockSheet(): IO.IO<Sheet> {
+  return IO.of({
+    id: `us_sh_${randomId()()}`,
+    config: {
+      access: faker.helpers.arrayElements(["*", "add", "delete", "edit", "import"]),
+      actions: [
+        {
+          confirm: faker.helpers.arrayElement([false, true]),
+          description: faker.lorem.words(3),
+          icon: faker.lorem.word(),
+          inputForm: {
+            fields: [
+              {
+                config: {
+                  options: {
+                    color: faker.lorem.word(),
+                    description: faker.lorem.words(3),
+                    icon: faker.lorem.word(),
+                    label: faker.lorem.word(),
+                    meta: {},
+                    value: faker.helpers.arrayElement([
+                      faker.helpers.arrayElement([false, true]),
+                      faker.number.int(),
+                      faker.lorem.word(),
+                    ]),
+                  },
+                },
+                constraints: [{ type: "required" }],
+                description: faker.lorem.words(3),
+                key: faker.lorem.word(),
+                label: faker.lorem.word(),
+                type: faker.helpers.arrayElement([
+                  "boolean",
+                  "enum",
+                  "number",
+                  "string",
+                  "textarea",
+                ]),
+              },
+            ],
+            type: "simple",
+          },
+          label: faker.lorem.word(),
+          mode: faker.helpers.arrayElement(["background", "foreground"]),
+          operation: faker.lorem.word(),
+          primary: faker.helpers.arrayElement([false, true]),
+          requireAllValid: faker.helpers.arrayElement([false, true]),
+          requireSelection: faker.helpers.arrayElement([false, true]),
+          schedule: faker.helpers.arrayElement(["daily", "hourly", "weekly"]),
+          tooltip: faker.lorem.word(),
+        },
+      ],
+      allowAdditionalFields: faker.helpers.arrayElement([false, true]),
+      description: faker.lorem.words(3),
+      fields: [
+        {
+          constraints: [{ type: "required" }],
+          description: faker.lorem.words(3),
+          key: faker.lorem.word(),
+          label: faker.lorem.word(),
+          metadata: {},
+          readonly: faker.helpers.arrayElement([false, true]),
+          treatments: [faker.lorem.word()],
+          type: faker.lorem.word(),
+        },
+      ],
+      metadata: {},
+      name: faker.lorem.word(),
+      readonly: faker.helpers.arrayElement([false, true]),
+      slug: faker.lorem.word(),
+    },
+    countRecords: {
+      error: faker.number.int({ min: 0 }),
+      errorsByField: {},
+      total: faker.number.int({ min: 0 }),
+      valid: faker.number.int({ min: 0 }),
+    },
+    createdAt: faker.date.past().toISOString(),
+    name: faker.lorem.word(),
+    namespace: faker.lorem.word(),
+    updatedAt: faker.date.past().toISOString(),
+    workbookId: `us_wb_${randomId()()}`,
+  });
+}
+
+describe("sheets", () => {
+  describe("[Decoders]", () => {
+    it("Sheet", () => {
+      const decoded = pipe(_mkMockSheet()(), SheetCodec.decode);
+
+      expect(E.isRight(decoded)).toBe(true);
+    });
+  });
+
+  describe("[Mocks]", () => {
+    const secret: string = "secret";
+    const environmentId: string = "environmentId";
+    const client = mkApiClient(secret, environmentId);
+    const baseUrl: string = "https://platform.flatfile.com/api/v1";
+
+    it("should handle failure when creating a Sheet", async () => {
+      // setup
+      const restHandlers = [
+        rest.post(`${baseUrl}/sheets`, (_req, res, ctx) => {
+          return res(
+            ctx.status(400),
+            ctx.json({
+              errors: [
+                {
+                  key: faker.lorem.word(),
+                  message: faker.lorem.sentence(),
+                },
+              ],
+            }),
+          );
+        }),
+      ];
+
+      const server = setupServer(...restHandlers);
+      server.listen({ onUnhandledRequest: "error" });
+
+      // test
+      const resp = await client.sheets.create({} as CreateSheetInput);
+
+      match(resp)
+        .with({ _tag: "http_error" }, (httpError) => expect(httpError.statusCode).toEqual(400))
+        .otherwise(() => assert.fail(`Received unexpected tag: ${resp._tag}`));
+
+      // teardown
+      server.close();
+    });
+
+    it("should handle decoder errors when creating a Sheet", async () => {
+      // setup
+      const mockSheet: Sheet = _mkMockSheet()();
+
+      const restHandlers = [
+        rest.post(`${baseUrl}/sheets`, (_req, res, ctx) => {
+          return res(
+            ctx.status(200),
+            ctx.json({
+              data: {
+                ...mockSheet,
+                name: undefined,
+              },
+            }),
+          );
+        }),
+      ];
+
+      const server = setupServer(...restHandlers);
+      server.listen({ onUnhandledRequest: "error" });
+
+      // test
+      const resp = await client.sheets.create(mockSheet);
+
+      match(resp)
+        .with({ _tag: "decoder_errors" }, ({ reasons }) =>
+          expect(reasons).toStrictEqual([`Expecting string at 0.name but instead got: undefined`]),
+        )
+        .otherwise(() => assert.fail(`Received unexpected tag: ${resp._tag}`));
+
+      // teardown
+      server.close();
+    });
+
+    it("should handle successfully creating a Sheet", async () => {
+      // setup
+      const mockSheet: Sheet = _mkMockSheet()();
+
+      const restHandlers = [
+        rest.post(`${baseUrl}/sheets`, (_req, res, ctx) => {
+          return res(ctx.status(200), ctx.json({ data: mockSheet }));
+        }),
+      ];
+
+      const server = setupServer(...restHandlers);
+      server.listen({ onUnhandledRequest: "error" });
+
+      // test
+      const resp = await client.sheets.create(mockSheet);
+
+      match(resp)
+        .with({ _tag: "successful" }, ({ data }) => expect(data).toStrictEqual(mockSheet))
+        .otherwise(() => assert.fail(`Received unexpected tag: ${resp._tag}`));
+
+      // teardown
+      server.close();
+    });
+  });
+});

--- a/packages/ffx-api/test/sheets.spec.mts
+++ b/packages/ffx-api/test/sheets.spec.mts
@@ -7,8 +7,15 @@ import { setupServer } from "msw/node";
 import { match } from "ts-pattern";
 
 import mkApiClient from "../src/index.mjs";
-import { EnvironmentId } from "../src/lib/environments.mjs";
-import { CreateSheetInput, Sheet, Sheets, SheetCodec, SheetIdCodec } from "../src/lib/sheets.mjs";
+import { EnvironmentId, isoEnvironmentId } from "../src/lib/environments.mjs";
+import {
+  CreateSheetInput,
+  Sheet,
+  Sheets,
+  codecSheet,
+  codecSheetId,
+  isoSheetId,
+} from "../src/lib/sheets.mjs";
 
 function randomId(): IO.IO<string> {
   return IO.of(Math.random().toString(16).slice(2, 10));
@@ -16,7 +23,7 @@ function randomId(): IO.IO<string> {
 
 function _mkMockSheet(): IO.IO<Sheet> {
   return IO.of({
-    id: SheetIdCodec.encode(`us_sh_${randomId()()}`),
+    id: isoSheetId.wrap(`us_sh_${randomId()()}`),
     config: {
       access: faker.helpers.arrayElements(["*", "add", "delete", "edit", "import"]),
       actions: [
@@ -102,21 +109,21 @@ function _mkMockSheet(): IO.IO<Sheet> {
 describe("sheets", () => {
   describe("[Codecs]", () => {
     it("Sheet", () => {
-      const decoded = pipe(_mkMockSheet()(), SheetCodec.decode);
+      const decoded = pipe(_mkMockSheet()(), codecSheet.decode);
 
       expect(E.isRight(decoded)).toBe(true);
     });
 
     it("SheetId", () => {
-      const encoded = SheetIdCodec.encode(`us_sh_${randomId()()}`);
+      const encoded = isoSheetId.wrap(`us_sh_${randomId()()}`);
 
-      expect(SheetIdCodec.is(encoded)).toBe(true);
+      expect(codecSheetId.is(encoded)).toBe(true);
     });
   });
 
   describe("[Mocks]", () => {
     const secret: string = "secret";
-    const environmentId: EnvironmentId = "environmentId";
+    const environmentId: EnvironmentId = isoEnvironmentId.wrap("environmentId");
     const client = mkApiClient(secret, environmentId);
     const baseUrl: string = "https://platform.flatfile.com/api/v1";
 

--- a/packages/ffx-api/test/workbooks.spec.mts
+++ b/packages/ffx-api/test/workbooks.spec.mts
@@ -61,6 +61,8 @@ describe("sheets", () => {
 
     it("should handle failure when creating a Workbook", async () => {
       // setup
+      const mockWorkbook: Workbook = _mkMockWorkbook()();
+
       const restHandlers = [
         rest.post(`${baseUrl}/workbooks`, (_req, res, ctx) => {
           return res(
@@ -81,7 +83,16 @@ describe("sheets", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.workbooks.create({} as CreateWorkbookInput);
+      const resp = await client.workbooks.create({
+        actions: mockWorkbook.actions,
+        environmentId: mockWorkbook.environmentId,
+        labels: mockWorkbook.labels,
+        metadata: mockWorkbook.metadata,
+        name: mockWorkbook.name,
+        namespace: mockWorkbook.namespace,
+        sheets: mockWorkbook.sheets,
+        spaceId: mockWorkbook.spaceId,
+      });
 
       match(resp)
         .with({ _tag: "http_error" }, (httpError) => expect(httpError.statusCode).toEqual(400))
@@ -113,7 +124,16 @@ describe("sheets", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.workbooks.create(mockWorkbook);
+      const resp = await client.workbooks.create({
+        actions: mockWorkbook.actions,
+        environmentId: mockWorkbook.environmentId,
+        labels: mockWorkbook.labels,
+        metadata: mockWorkbook.metadata,
+        name: mockWorkbook.name,
+        namespace: mockWorkbook.namespace,
+        sheets: mockWorkbook.sheets,
+        spaceId: mockWorkbook.spaceId,
+      });
 
       match(resp)
         .with({ _tag: "decoder_errors" }, ({ reasons }) =>
@@ -139,7 +159,16 @@ describe("sheets", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.workbooks.create(mockWorkbook);
+      const resp = await client.workbooks.create({
+        actions: mockWorkbook.actions,
+        environmentId: mockWorkbook.environmentId,
+        labels: mockWorkbook.labels,
+        metadata: mockWorkbook.metadata,
+        name: mockWorkbook.name,
+        namespace: mockWorkbook.namespace,
+        sheets: mockWorkbook.sheets,
+        spaceId: mockWorkbook.spaceId,
+      });
 
       match(resp)
         .with({ _tag: "successful" }, ({ data }) => expect(data).toStrictEqual(mockWorkbook))
@@ -460,7 +489,16 @@ describe("sheets", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.workbooks.update(mockWorkbook);
+      const resp = await client.workbooks.update(mockWorkbook.id, {
+        actions: mockWorkbook.actions,
+        environmentId: mockWorkbook.environmentId,
+        labels: mockWorkbook.labels,
+        metadata: mockWorkbook.metadata,
+        name: mockWorkbook.name,
+        namespace: mockWorkbook.namespace,
+        sheets: mockWorkbook.sheets,
+        spaceId: mockWorkbook.spaceId,
+      });
 
       match(resp)
         .with({ _tag: "http_error" }, (httpError) => expect(httpError.statusCode).toEqual(400))
@@ -492,7 +530,16 @@ describe("sheets", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.workbooks.update(mockWorkbook);
+      const resp = await client.workbooks.update(mockWorkbook.id, {
+        actions: mockWorkbook.actions,
+        environmentId: mockWorkbook.environmentId,
+        labels: mockWorkbook.labels,
+        metadata: mockWorkbook.metadata,
+        name: mockWorkbook.name,
+        namespace: mockWorkbook.namespace,
+        sheets: mockWorkbook.sheets,
+        spaceId: mockWorkbook.spaceId,
+      });
 
       match(resp)
         .with({ _tag: "decoder_errors" }, ({ reasons }) =>
@@ -523,7 +570,16 @@ describe("sheets", () => {
       server.listen({ onUnhandledRequest: "error" });
 
       // test
-      const resp = await client.workbooks.update(mockWorkbook);
+      const resp = await client.workbooks.update(mockWorkbook.id, {
+        actions: mockWorkbook.actions,
+        environmentId: mockWorkbook.environmentId,
+        labels: mockWorkbook.labels,
+        metadata: mockWorkbook.metadata,
+        name: mockWorkbook.name,
+        namespace: mockWorkbook.namespace,
+        sheets: mockWorkbook.sheets,
+        spaceId: mockWorkbook.spaceId,
+      });
 
       match(resp)
         .with({ _tag: "successful" }, ({ data }) => expect(data).toStrictEqual(mockWorkbook))

--- a/packages/ffx-api/test/workbooks.spec.mts
+++ b/packages/ffx-api/test/workbooks.spec.mts
@@ -8,7 +8,7 @@ import { match } from "ts-pattern";
 
 import mkApiClient from "../src/index.mjs";
 import { SpaceIdCodec } from "../src/lib/documents.mjs";
-import { EnvironmentIdCodec } from "../src/lib/environments.mjs";
+import { EnvironmentId, EnvironmentIdCodec } from "../src/lib/environments.mjs";
 import {
   CreateWorkbookInput,
   Workbook,
@@ -54,7 +54,7 @@ describe("sheets", () => {
 
   describe("[Mocks]", () => {
     const secret: string = "secret";
-    const environmentId: string = "environmentId";
+    const environmentId: EnvironmentId = "environmentId";
     const client = mkApiClient(secret, environmentId);
     const baseUrl: string = "https://platform.flatfile.com/api/v1";
 

--- a/packages/ffx-api/test/workbooks.spec.mts
+++ b/packages/ffx-api/test/workbooks.spec.mts
@@ -7,7 +7,9 @@ import { setupServer } from "msw/node";
 import { match } from "ts-pattern";
 
 import mkApiClient from "../src/index.mjs";
-import { Workbook, WorkbookCodec } from "../src/lib/workbooks.mjs";
+import { SpaceIdCodec } from "../src/lib/documents.mjs";
+import { EnvironmentIdCodec } from "../src/lib/environments.mjs";
+import { Workbook, WorkbookCodec, WorkbookIdCodec } from "../src/lib/workbooks.mjs";
 
 function randomId(): IO.IO<string> {
   return IO.of(Math.random().toString(16).slice(2, 10));
@@ -15,26 +17,43 @@ function randomId(): IO.IO<string> {
 
 function _mkMockWorkbook(): IO.IO<Workbook> {
   return IO.of({
-    id: `us_wb_${randomId()()}`,
+    id: WorkbookIdCodec.encode(`us_wb_${randomId()()}`),
     actions: [],
     createdAt: faker.date.past().toISOString(),
-    environmentId: `us_env_${randomId()()}`,
+    environmentId: EnvironmentIdCodec.encode(`us_env_${randomId()()}`),
     labels: [faker.lorem.word()],
     metadata: {},
     name: faker.lorem.word(),
     namespace: faker.lorem.word(),
     sheets: [],
-    spaceId: `us_sp_${randomId()()}`,
+    spaceId: SpaceIdCodec.encode(`us_sp_${randomId()()}`),
     updatedAt: faker.date.past().toISOString(),
   });
 }
 
 describe("sheets", () => {
-  describe("[Decoders]", () => {
+  describe("[Codecs]", () => {
     it("Sheet", () => {
       const decoded = pipe(_mkMockWorkbook()(), WorkbookCodec.decode);
 
       expect(E.isRight(decoded)).toBe(true);
+    });
+
+    it("WorkbookId", () => {
+      const encoded = WorkbookIdCodec.encode(`us_wb_${randomId()()}`);
+
+      expect(WorkbookIdCodec.is(encoded)).toBe(true);
+    });
+  });
+
+  describe("[Mocks]", () => {
+    const secret: string = "secret";
+    const environmentId: string = "environmentId";
+    const client = mkApiClient(secret, environmentId);
+    const baseUrl: string = "https://platform.flatfile.com/api/v1";
+
+    it("should pass", () => {
+      expect(true).toBe(true);
     });
   });
 });

--- a/packages/ffx-api/test/workbooks.spec.mts
+++ b/packages/ffx-api/test/workbooks.spec.mts
@@ -7,14 +7,15 @@ import { setupServer } from "msw/node";
 import { match } from "ts-pattern";
 
 import mkApiClient from "../src/index.mjs";
-import { SpaceIdCodec } from "../src/lib/documents.mjs";
-import { EnvironmentId, EnvironmentIdCodec } from "../src/lib/environments.mjs";
+import { isoSpaceId } from "../src/lib/documents.mjs";
+import { EnvironmentId, isoEnvironmentId } from "../src/lib/environments.mjs";
 import {
   CreateWorkbookInput,
   Workbook,
-  WorkbookCodec,
-  WorkbookIdCodec,
   Workbooks,
+  codecWorkbook,
+  codecWorkbookId,
+  isoWorkbookId,
 } from "../src/lib/workbooks.mjs";
 
 function randomId(): IO.IO<string> {
@@ -23,16 +24,16 @@ function randomId(): IO.IO<string> {
 
 function _mkMockWorkbook(): IO.IO<Workbook> {
   return IO.of({
-    id: WorkbookIdCodec.encode(`us_wb_${randomId()()}`),
+    id: isoWorkbookId.wrap(`us_wb_${randomId()()}`),
     actions: [],
     createdAt: faker.date.past().toISOString(),
-    environmentId: EnvironmentIdCodec.encode(`us_env_${randomId()()}`),
+    environmentId: isoEnvironmentId.wrap(`us_env_${randomId()()}`),
     labels: [faker.lorem.word()],
     metadata: {},
     name: faker.lorem.word(),
     namespace: faker.lorem.word(),
     sheets: [],
-    spaceId: SpaceIdCodec.encode(`us_sp_${randomId()()}`),
+    spaceId: isoSpaceId.wrap(`us_sp_${randomId()()}`),
     updatedAt: faker.date.past().toISOString(),
   });
 }
@@ -40,21 +41,21 @@ function _mkMockWorkbook(): IO.IO<Workbook> {
 describe("sheets", () => {
   describe("[Codecs]", () => {
     it("Sheet", () => {
-      const decoded = pipe(_mkMockWorkbook()(), WorkbookCodec.decode);
+      const decoded = pipe(_mkMockWorkbook()(), codecWorkbook.decode);
 
       expect(E.isRight(decoded)).toBe(true);
     });
 
     it("WorkbookId", () => {
-      const encoded = WorkbookIdCodec.encode(`us_wb_${randomId()()}`);
+      const encoded = isoWorkbookId.wrap(`us_wb_${randomId()()}`);
 
-      expect(WorkbookIdCodec.is(encoded)).toBe(true);
+      expect(codecWorkbookId.is(encoded)).toBe(true);
     });
   });
 
   describe("[Mocks]", () => {
     const secret: string = "secret";
-    const environmentId: EnvironmentId = "environmentId";
+    const environmentId: EnvironmentId = isoEnvironmentId.wrap("environmentId");
     const client = mkApiClient(secret, environmentId);
     const baseUrl: string = "https://platform.flatfile.com/api/v1";
 

--- a/packages/ffx-api/test/workbooks.spec.mts
+++ b/packages/ffx-api/test/workbooks.spec.mts
@@ -1,0 +1,40 @@
+import { faker } from "@faker-js/faker";
+import * as E from "fp-ts/Either";
+import { pipe } from "fp-ts/function";
+import * as IO from "fp-ts/IO";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
+import { match } from "ts-pattern";
+
+import mkApiClient from "../src/index.mjs";
+import { Workbook, WorkbookCodec } from "../src/lib/workbooks.mjs";
+
+function randomId(): IO.IO<string> {
+  return IO.of(Math.random().toString(16).slice(2, 10));
+}
+
+function _mkMockWorkbook(): IO.IO<Workbook> {
+  return IO.of({
+    id: `us_wb_${randomId()()}`,
+    actions: [],
+    createdAt: faker.date.past().toISOString(),
+    environmentId: `us_env_${randomId()()}`,
+    labels: [faker.lorem.word()],
+    metadata: {},
+    name: faker.lorem.word(),
+    namespace: faker.lorem.word(),
+    sheets: [],
+    spaceId: `us_sp_${randomId()()}`,
+    updatedAt: faker.date.past().toISOString(),
+  });
+}
+
+describe("sheets", () => {
+  describe("[Decoders]", () => {
+    it("Sheet", () => {
+      const decoded = pipe(_mkMockWorkbook()(), WorkbookCodec.decode);
+
+      expect(E.isRight(decoded)).toBe(true);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,12 @@ importers:
       io-ts-reporters:
         specifier: ^2.0.0
         version: 2.0.1(fp-ts@2.16.1)(io-ts@2.2.20)
+      monocle-ts:
+        specifier: ^2.3.13
+        version: 2.3.13(fp-ts@2.16.1)
+      newtype-ts:
+        specifier: ^0.3.5
+        version: 0.3.5(fp-ts@2.16.1)(monocle-ts@2.3.13)
 
   packages/ffx-cli:
     dependencies:


### PR DESCRIPTION
# Description

Add `sheets` and `workbooks` endpoints to be used by `ffx-cli` and `ffx-orm`. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests (when necessary).
- [x] I have documented the code with examples and TSDoc.
